### PR TITLE
move link local address generation into the RUG

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='Akanda Router Update Generator',
-    version='0.1.2',
+    version='0.1.3',
     description='A service that manages tenant Akanda router instances',
     author='DreamHost',
     author_email='dev-community@dreamhost.com',

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -1,0 +1,18 @@
+import mock
+import unittest2 as unittest
+
+from akanda.rug import manager
+
+
+class TestManager(unittest.TestCase):
+    def test_get_management_address(self):
+        with mock.patch.object(manager.cfg, 'CONF') as conf:
+            conf.management_prefix = 'fdca:3ba5:a17a:acda::/64'
+
+            router = mock.Mock()
+            router.management_port.mac_address = 'fa:16:3e:aa:dc:98'
+
+            self.assertEqual(
+                'fdca:3ba5:a17a:acda:f816:3eff:feaa:dc98',
+                manager._get_management_address(router)
+            )


### PR DESCRIPTION
This works around the broken the netaddr implementation packaged with Ubuntu
which contains an algorithmic error.  Later versions of netaddr have
fixed the error, but Canonical has not backported it.
