### PR TITLE
Improve error message for failed bandwidth update

### DIFF
--- a/akanda/rug/manager.py
+++ b/akanda/rug/manager.py
@@ -223,8 +223,9 @@ class AkandaL3Manager(notification.NotificationMixin,
 
     def report_bandwidth(self, router):
         try:
+            ip = _get_management_address(router)
             bandwidth = router_api.read_labels(
-                _get_management_address(router),
+                ip,
                 cfg.CONF.akanda_mgt_service_port)
 
             if bandwidth:
@@ -239,7 +240,8 @@ class AkandaL3Manager(notification.NotificationMixin,
                            cfg.CONF.notification_topic,
                            message)
         except:
-            LOG.exception('Error during bandwidth report.')
+            LOG.exception('Error during bandwidth report for %s (ip:%s)'
+                          % (router, ip))
 
     def check_health(self, router):
             if not self.router_is_alive(router):


### PR DESCRIPTION
The error printed when updating the bandwidth usage
for a router did not include any details about which
router was causing the problem.

Change-Id: I9fd33b8fe6f4a5842b6d6a3d7c82bfbf9d7b65df
Signed-off-by: Doug Hellmann doug.hellmann@dreamhost.com
