### PR TITLE
Exclude test folder from package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'oslo.config'
     ],
     namespace_packages=['akanda'],
-    packages=find_packages(),
+    packages=find_packages(exclude=['test']),
     include_package_data=True,
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
DHC-1102

Ignore the test directory when looking for python packages to
avoid having the files installed

Change-Id: Ia30e821109c0f75f0f0c51bb995b2099aa30e063
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
