### PR TITLE
Abort a task that is trying to update a router that is no longer available

### DIFF
--- a/akanda/rug/api/quantum.py
+++ b/akanda/rug/api/quantum.py
@@ -6,6 +6,7 @@ import netaddr
 from oslo.config import cfg
 from quantumclient.v2_0 import client
 
+from akanda.rug.common.exceptions import AbortTask
 from akanda.rug.openstack.common import importutils
 from akanda.rug.openstack.common import context
 from akanda.rug.openstack.common.rpc import proxy
@@ -332,9 +333,11 @@ class Quantum(object):
 
     def get_router_detail(self, router_id):
         """Return detailed information about a router and it's networks."""
-        return Router.from_dict(
-            self.rpc_client.get_routers(router_id=router_id)[0]
-        )
+        router = self.rpc_client.get_routers(router_id=router_id)
+        try:
+            return Router.from_dict(router[0])
+        except IndexError:
+            raise AbortTask('the router is no longer available')
 
     def get_router_for_tenant(self, tenant_id):
         response = self.api_client.list_routers(tenant_id=tenant_id)

--- a/akanda/rug/common/exceptions.py
+++ b/akanda/rug/common/exceptions.py
@@ -1,0 +1,3 @@
+class AbortTask(Exception):
+    """ Raised when a task shouldn't be enqueued anymore. """
+    pass

--- a/akanda/rug/common/task.py
+++ b/akanda/rug/common/task.py
@@ -2,6 +2,9 @@ import logging
 
 import eventlet
 
+from akanda.rug.common.exceptions import AbortTask
+
+
 LOG = logging.getLogger(__name__)
 
 
@@ -50,6 +53,8 @@ class TaskManager(object):
                 LOG.debug('starting %s', task)
                 task()
                 LOG.debug('success for task %s', task)
+            except AbortTask as e:
+                LOG.warn('Task aborted: %s (%s)', e, task)
             except Exception as e:
                 try:
                     if isinstance(e, Warning):


### PR DESCRIPTION
Some tasks may find themselves in a situations where they are
going to fail and to be enqueued untill they reach the
max_attempts value. (Ex. an update_router task in the rug's
queue whos router has been deleted in Quantum). This commit
adds logic to abort those tasks.

Change-Id: Ia7eac41843b5870739c13c348945ee0b809196a7
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
