### PR TITLE
Add reason message to the task object.

### DIFF
--- a/akanda/rug/common/task.py
+++ b/akanda/rug/common/task.py
@@ -9,11 +9,12 @@ LOG = logging.getLogger(__name__)
 
 
 class Task(object):
-    def __init__(self, method, data, max_attempts=3):
+    def __init__(self, method, data, max_attempts=3, reason=None):
         self.method = method
         self.data = data
         self.current = 0
         self.max_attempts = max_attempts
+        self.reason = reason
 
     def __call__(self):
         self.current += 1
@@ -23,9 +24,10 @@ class Task(object):
         return self.current < self.max_attempts
 
     def __repr__(self):
-        msg = '<Task method: %s data: %s attempt: %d/%d >'
+        msg = '<Task method: %s reason: (%s) data: %s attempt: %d/%d >'
 
         return msg % (self.method.__name__,
+                      self.reason,
                       self.data,
                       self.current,
                       self.max_attempts)
@@ -38,8 +40,8 @@ class TaskManager(object):
         self.blocked = set()
         self.max_requeue_delay = max_requeue_delay
 
-    def put(self, method, data, max_attempts=3):
-        self.task_queue.put(Task(method, data, max_attempts))
+    def put(self, method, data, max_attempts=3, reason=None):
+        self.task_queue.put(Task(method, data, max_attempts, reason))
 
     def start(self):
         eventlet.spawn(self._serialized_task_runner)

--- a/akanda/rug/manager.py
+++ b/akanda/rug/manager.py
@@ -111,7 +111,7 @@ class AkandaL3Manager(notification.NotificationMixin,
         LOG.info('start health check queueing')
         for rtr in self.cache.routers():
             self.task_mgr.put(self.check_health, rtr,
-                              reason='Periodic healt check')
+                              reason='Periodic health check')
 
     @periodic_task.periodic_task(ticks_between_runs=1)
     def report_bandwidth_usage(self, context):
@@ -141,7 +141,7 @@ class AkandaL3Manager(notification.NotificationMixin,
             if rtr:
                 self.task_mgr.put(self.update_router, rtr.id,
                                   reason='Default handler notification '
-                                  'reiceved')
+                                  'received')
 
     @notification.handles('subnet.create.end',
                           'subnet.change.end',


### PR DESCRIPTION
Task like update_router are pushed to the queue by several methods
of the AkandaL3Manager. If a task is failing it's really hard to
give it context to figure out what is going on. Adding a reason
string to the task should make it a little clearer why is running
and help the debugging phase.

Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com

Change-Id: I63938bd32c9c086ef12c5f905023dd49e50f8f81
