### PR TITLE
Work-around for flaky github download URL

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,15 @@ envlist = py27,style
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
-deps = -r{toxinidir}/test_requirements.txt
+deps = 
+  # Temporarily force the download location for netaddr because github
+  # is being flaky and not letting us get to the download via the
+  # registered http-based URL.
+  https://github.com/downloads/drkjam/netaddr/netaddr-0.7.10.tar.gz
+  -r{toxinidir}/test_requirements.txt
 commands = nosetests {posargs}
 sitepackages = False
+downloadcache = {toxworkdir}/_downloads
 
 [tox:jenkins]
 


### PR DESCRIPTION
Change-Id: I5c4858ccde37e5aa1492f18b8c425e9bc0c129fe
Signed-off-by: Doug Hellmann doug.hellmann@dreamhost.com
