### PR TITLE
Replacing private method use in create notification listener

### DIFF
--- a/akanda/rug/common/notification.py
+++ b/akanda/rug/common/notification.py
@@ -17,9 +17,10 @@ class NotificationMixin(object):
                     event_type, []).append(method[1])
 
         self.notification_connection = rpc.create_connection(new=True)
-        self.notification_connection.declare_topic_consumer(
-            topic=topic,
-            callback=self._notification_mixin_dispatcher,
+        self.notification_connection.join_consumer_pool(
+            self._notification_mixin_dispatcher,
+            'akanda.notifications',
+            topic,
             exchange_name=exchange_name)
         self.notification_connection.consume_in_thread()
 

--- a/test/unit/common/test_notification.py
+++ b/test/unit/common/test_notification.py
@@ -29,9 +29,10 @@ class TestNotificationMixin(unittest.TestCase):
 
             expected = [
                 mock.call.create_connection(new=True),
-                mock.call.create_connection().declare_topic_consumer(
-                    topic='the_topic',
-                    callback=n._notification_mixin_dispatcher,
+                mock.call.create_connection().join_consumer_pool(
+                    n._notification_mixin_dispatcher,
+                    'akanda.notifications',
+                    'the_topic',
                     exchange_name='the_exch'),
                 mock.call.create_connection().consume_in_thread()]
 


### PR DESCRIPTION
declare_topic_consumer() is only defined by the Kombu implementation,
but the public method join_consumer_pool() eventually sets the
connection to a pool via declare_topic_consumer(), so use that instead.
