### PR TITLE
Manage worker threads and route messages to the appropriate state machine

### DIFF
--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -30,6 +30,14 @@ def main(argv=sys.argv[1:]):
         cfg.StrOpt('host',
                    default=socket.getfqdn(),
                    help="The hostname Akanda is running on"),
+
+        # FIXME(dhellmann): Use a separate group for these auth params
+        cfg.StrOpt('admin_user'),
+        cfg.StrOpt('admin_password', secret=True),
+        cfg.StrOpt('admin_tenant_name'),
+        cfg.StrOpt('auth_url'),
+        cfg.StrOpt('auth_strategy', default='keystone'),
+        cfg.StrOpt('auth_region'),
     ])
     # FIXME: Convert these to regular options, not command line options.
     cfg.CONF.register_cli_opts([

--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -51,7 +51,12 @@ def main(argv=sys.argv[1:]):
     cfg.CONF(argv, project='akanda')
     logging.basicConfig(
         level=logging.DEBUG,
-        format='%(processName)s:%(name)s:%(levelname)s:%(message)s',
+        format=':'.join('%(' + n + ')s'
+                        for n in ['processName',
+                                  'threadName',
+                                  'name',
+                                  'levelname',
+                                  'message']),
     )
 
     # Set up the queue to move messages between the eventlet-based

--- a/akanda/rug/notifications.py
+++ b/akanda/rug/notifications.py
@@ -64,7 +64,7 @@ def _make_event_from_message(message):
         elif event_type.endswith('.end'):
             crud = event.UPDATE
         else:
-            LOG.debug('ignoring message %r', message)
+            # LOG.debug('ignoring message %r', message)
             return None
     return event.Event(tenant_id, router_id, crud, message)
 
@@ -151,7 +151,7 @@ def listen(host_id, amqp_url, notification_queue):
 
     def _process_message(body, message):
         "Send the message through the notification queue"
-        LOG.debug('received %r', body)
+        #LOG.debug('received %r', body)
         # TODO:
         #  1. Ignore notification messages that we don't care about.
         #  2. Convert notification and rpc messages to a common format
@@ -173,4 +173,7 @@ def listen(host_id, amqp_url, notification_queue):
     consumer.consume()
 
     while True:
-        connection.drain_events()
+        try:
+            connection.drain_events()
+        except KeyboardInterrupt:
+            break

--- a/akanda/rug/scheduler.py
+++ b/akanda/rug/scheduler.py
@@ -53,13 +53,13 @@ class Scheduler(object):
     """Managers a worker pool and redistributes messages.
     """
 
-    def __init__(self, num_workers, worker_func):
+    def __init__(self, num_workers, worker_factory):
         """
         :param num_workers: The number of worker processes to create.
         :type num_workers: int
         :param worker_func: Callable for the worker processes to use
                             when a notification is received.
-        :type worker_func: Callable taking one argument.
+        :type worker_factory: Callable to create Worker instances.
         """
         if num_workers < 1:
             raise ValueError('Need at least one worker process')
@@ -74,7 +74,7 @@ class Scheduler(object):
                 target=_worker,
                 kwargs={
                     'inq': wq,
-                    'callback': worker_func,
+                    'callback': worker_factory().handle_message,
                 },
                 name='worker-%02d' % i,
             )

--- a/akanda/rug/state.py
+++ b/akanda/rug/state.py
@@ -6,22 +6,27 @@ import logging
 
 class Automaton(object):
 
-    def __init__(self, router_id, delete_callback):
+    def __init__(self, router_id, delete_callback, queue):
         """
         :param router_id: UUID of the router being managed
         :type router_id: str
         :param delete_callback: Invoked when the Automaton decides
                                 the router should be deleted.
         :type delete_callback: callable
+        :param queue: Input queue for messages
+        :type queue: Queue.Queue
         """
         self.router_id = router_id
         self.delete_callback = delete_callback
+        self.queue = queue
         self.log = logging.getLogger(__name__ + '.' + router_id)
 
     def service_shutdown(self):
         "Called when the parent process is being stopped"
 
-    def update(self, message):
+    def update(self):
         "Called when the router config should be changed"
-        self.log.debug('update: %r', message)
-        # TODO: Manage the router!
+        while not self.queue.empty():
+            message = self.queue.get()
+            self.log.debug('update: %r', message)
+            # TODO: Manage the router!

--- a/akanda/rug/tenant.py
+++ b/akanda/rug/tenant.py
@@ -1,0 +1,46 @@
+"""Manage the routers for a given tenant.
+"""
+
+import logging
+
+from akanda.rug import state
+
+LOG = logging.getLogger(__name__)
+
+
+class TenantRouterManager(object):
+    """Keep track of the state machines for the routers for a given tenant.
+    """
+
+    def __init__(self, tenant_id):
+        self.state_machines = {}
+
+    def _delete_router(self, router_id):
+        "Called when the Automaton decides the router can be deleted"
+        if router_id in self.state_machines:
+            LOG.debug('deleting state machine for %s', router_id)
+            del self.state_machines[router_id]
+
+    def shutdown(self):
+        LOG.info('shutting down')
+        for rid, sm in self.state_machines.items():
+            try:
+                sm.service_shutdown()
+            except Exception:
+                LOG.exception(
+                    'Failed to shutdown state machine for %s' % rid
+                )
+
+    def handle_message(self, message):
+        router_id = message.router_id
+        if router_id is None:
+            LOG.debug('do not know how to handle %r', message)
+        else:
+            if router_id not in self.state_machines:
+                self.state_machines[router_id] = state.Automaton(
+                    router_id=router_id,
+                    delete_callback=self._delete_router,
+                )
+            sm = self.state_machines[router_id]
+            sm.update(message)
+

--- a/akanda/rug/test/unit/test_scheduler.py
+++ b/akanda/rug/test/unit/test_scheduler.py
@@ -18,13 +18,13 @@ class TestScheduler(unittest.TestCase):
 
     @mock.patch('multiprocessing.Process')
     def test_creating_workers(self, process):
-        s = scheduler.Scheduler(2, lambda x: x)
+        s = scheduler.Scheduler(2, mock.Mock)
         self.assertEqual(2, len(s.workers))
 
     @mock.patch('multiprocessing.Process')
     @mock.patch('multiprocessing.JoinableQueue')
     def test_stop(self, process, queue):
-        s = scheduler.Scheduler(2, lambda x: x)
+        s = scheduler.Scheduler(2, mock.Mock)
         s.stop()
         for w in s.workers:
             w['queue'].put.assert_called_once(None)

--- a/akanda/rug/test/unit/test_tenant.py
+++ b/akanda/rug/test/unit/test_tenant.py
@@ -1,0 +1,32 @@
+import mock
+import unittest2 as unittest
+
+from akanda.rug import event
+from akanda.rug import tenant
+
+
+class TestTenantRouterManager(unittest.TestCase):
+
+    def setUp(self):
+        super(TestTenantRouterManager, self).setUp()
+        self.trm = tenant.TenantRouterManager('1234')
+
+    @mock.patch('akanda.rug.state.Automaton')
+    def test_new_router(self, automaton):
+        msg = event.Event(
+            tenant_id='1234',
+            router_id='5678',
+            crud=event.CREATE,
+            body={'key': 'value'},
+        )
+        self.trm.handle_message(msg)
+        self.assertIn('5678', self.trm.state_machines)
+        automaton.assert_called_with(
+            router_id='5678',
+            delete_callback=self.trm._delete_router,
+        )
+
+    def test_delete_router(self):
+        self.trm.state_machines['1234'] = mock.Mock()
+        self.trm._delete_router('1234')
+        self.assertNotIn('1234', self.trm.state_machines)

--- a/akanda/rug/test/unit/test_tenant.py
+++ b/akanda/rug/test/unit/test_tenant.py
@@ -11,22 +11,48 @@ class TestTenantRouterManager(unittest.TestCase):
         super(TestTenantRouterManager, self).setUp()
         self.trm = tenant.TenantRouterManager('1234')
 
-    @mock.patch('akanda.rug.state.Automaton')
-    def test_new_router(self, automaton):
+    def test_new_router(self):
         msg = event.Event(
             tenant_id='1234',
             router_id='5678',
             crud=event.CREATE,
             body={'key': 'value'},
         )
-        self.trm.handle_message(msg)
+        sm, inq = self.trm.get_state_machine(msg)
+        self.assertEqual(sm.router_id, '5678')
         self.assertIn('5678', self.trm.state_machines)
-        automaton.assert_called_with(
+
+    @mock.patch('akanda.rug.state.Automaton')
+    def test_existing_router(self, automaton):
+        msg = event.Event(
+            tenant_id='1234',
             router_id='5678',
-            delete_callback=self.trm._delete_router,
+            crud=event.CREATE,
+            body={'key': 'value'},
         )
+        # First time creates...
+        sm1, inq1 = self.trm.get_state_machine(msg)
+        # Second time should return the same objects...
+        sm2, inq2 = self.trm.get_state_machine(msg)
+        self.assertIs(sm1, sm2)
+        self.assertIs(inq1, inq2)
 
     def test_delete_router(self):
-        self.trm.state_machines['1234'] = mock.Mock()
+        self.trm.state_machines['1234'] = {
+            'sm': mock.Mock(),
+            'inq': mock.Mock(),
+        }
         self.trm._delete_router('1234')
         self.assertNotIn('1234', self.trm.state_machines)
+
+    def test_deleter_callback(self):
+        msg = event.Event(
+            tenant_id='1234',
+            router_id='5678',
+            crud=event.CREATE,
+            body={'key': 'value'},
+        )
+        sm, inq = self.trm.get_state_machine(msg)
+        self.assertIn('5678', self.trm.state_machines)
+        sm.delete_callback()
+        self.assertNotIn('5678', self.trm.state_machines)

--- a/akanda/rug/test/unit/test_tenant.py
+++ b/akanda/rug/test/unit/test_tenant.py
@@ -58,6 +58,29 @@ class TestTenantRouterManager(unittest.TestCase):
         self.assertIs(sm1, sm2)
         self.assertIs(inq1, inq2)
 
+    @mock.patch('akanda.rug.state.Automaton')
+    def test_existing_router_of_many(self, automaton):
+        sms = {}
+        for router_id in ['5678', 'ABCD', 'EFGH']:
+            msg = event.Event(
+                tenant_id='1234',
+                router_id=router_id,
+                crud=event.CREATE,
+                body={'key': 'value'},
+            )
+            # First time creates...
+            sm1, inq1 = self.trm.get_state_machine(msg)
+            sms[router_id] = sm1
+        # Second time should return the same objects...
+        msg = event.Event(
+            tenant_id='1234',
+            router_id='5678',
+            crud=event.CREATE,
+            body={'key': 'value'},
+        )
+        sm2, inq2 = self.trm.get_state_machine(msg)
+        self.assertIs(sm1, sms['5678'])
+
     def test_delete_router(self):
         self.trm.state_machines['1234'] = {
             'sm': mock.Mock(),

--- a/akanda/rug/test/unit/test_worker.py
+++ b/akanda/rug/test/unit/test_worker.py
@@ -1,3 +1,5 @@
+import mock
+
 import unittest2 as unittest
 
 from akanda.rug import event
@@ -10,7 +12,12 @@ class TestWorker(unittest.TestCase):
         super(TestWorker, self).setUp()
         self.w = worker.Worker(1)
 
-    def test_new_router(self):
+    def tearDown(self):
+        self.w._shutdown()
+        super(TestWorker, self).tearDown()
+
+    @mock.patch('akanda.rug.api.quantum.Quantum')
+    def test_new_router(self, quantum):
         msg = event.Event(
             tenant_id='1234',
             router_id='5678',

--- a/akanda/rug/test/unit/test_worker.py
+++ b/akanda/rug/test/unit/test_worker.py
@@ -1,4 +1,3 @@
-import mock
 import unittest2 as unittest
 
 from akanda.rug import event
@@ -11,16 +10,14 @@ class TestWorker(unittest.TestCase):
         super(TestWorker, self).setUp()
         self.w = worker.Worker(1)
 
-    @mock.patch('akanda.rug.tenant.TenantRouterManager')
-    def test_new_router(self, automaton):
+    def test_new_router(self):
         msg = event.Event(
             tenant_id='1234',
             router_id='5678',
             crud=event.CREATE,
             body={'key': 'value'},
         )
-        self.w.handle_message('1234', {'key': 'value'})
+        self.w.handle_message('1234', msg)
         self.assertIn('1234', self.w.tenant_managers)
-        automaton.assert_called_with(
-            tenant_id='1234',
-        )
+        trm = self.w.tenant_managers['1234']
+        self.assertEqual('1234', trm.tenant_id)

--- a/akanda/rug/test/unit/test_worker.py
+++ b/akanda/rug/test/unit/test_worker.py
@@ -6,25 +6,86 @@ from akanda.rug import event
 from akanda.rug import worker
 
 
-class TestWorker(unittest.TestCase):
-
-    def setUp(self):
-        super(TestWorker, self).setUp()
-        self.w = worker.Worker(1)
-
-    def tearDown(self):
-        self.w._shutdown()
-        super(TestWorker, self).tearDown()
+class TestWorkerCreatingRouter(unittest.TestCase):
 
     @mock.patch('akanda.rug.api.quantum.Quantum')
-    def test_new_router(self, quantum):
-        msg = event.Event(
-            tenant_id='1234',
-            router_id='5678',
+    def setUp(self, quantum):
+        super(TestWorkerCreatingRouter, self).setUp()
+        self.w = worker.Worker(0)
+        self.tenant_id = '1234'
+        self.router_id = '5678'
+        self.msg = event.Event(
+            tenant_id=self.tenant_id,
+            router_id=self.router_id,
             crud=event.CREATE,
             body={'key': 'value'},
         )
-        self.w.handle_message('1234', msg)
-        self.assertIn('1234', self.w.tenant_managers)
-        trm = self.w.tenant_managers['1234']
-        self.assertEqual('1234', trm.tenant_id)
+        self.w.handle_message(self.tenant_id, self.msg)
+
+    def tearDown(self):
+        self.w._shutdown()
+        super(TestWorkerCreatingRouter, self).tearDown()
+
+    def test_in_tenant_managers(self):
+        self.assertIn(self.tenant_id, self.w.tenant_managers)
+        trm = self.w.tenant_managers[self.tenant_id]
+        self.assertEqual(self.tenant_id, trm.tenant_id)
+
+    def test_message_enqueued(self):
+        trm = self.w.tenant_managers[self.tenant_id]
+        sm, inq = trm.get_state_machine(self.msg)
+        self.assertEqual(1, inq.qsize())
+
+    def test_being_updated_set(self):
+        self.assertIn(self.router_id, self.w.being_updated)
+
+
+class TestWorkerShutdown(unittest.TestCase):
+
+    @mock.patch('akanda.rug.api.quantum.Quantum')
+    def test_shutdown_on_null_message(self, quantum):
+        self.w = worker.Worker(0)
+        with mock.patch.object(self.w, '_shutdown') as meth:
+            self.w.handle_message(None, None)
+            meth.assert_called_once_with()
+
+    @mock.patch('akanda.rug.api.quantum.Quantum')
+    def test_stop_threads(self, quantum):
+        self.w = worker.Worker(1)
+        original_queue = self.w.work_queue
+        self.assertTrue(self.w._keep_going)
+        self.w._shutdown()
+        self.assertFalse(self.w._keep_going)
+        new_queue = self.w.work_queue
+        self.assertIsNot(original_queue, new_queue)
+
+
+class TestWorkerUpdateStateMachine(unittest.TestCase):
+
+    @mock.patch('akanda.rug.api.quantum.Quantum')
+    def test(self, quantum):
+        w = worker.Worker(0)
+        tenant_id = '1234'
+        router_id = '5678'
+        msg = event.Event(
+            tenant_id=tenant_id,
+            router_id=router_id,
+            crud=event.CREATE,
+            body={'key': 'value'},
+        )
+        # Create the router manager and state machine so we can
+        # replace the update() method with a mock.
+        trm = w._get_trm_for_tenant(tenant_id)
+        sm, inq = trm.get_state_machine(msg)
+        with mock.patch.object(sm, 'update') as meth:
+            w.handle_message(tenant_id, msg)
+            # Add a null message so the worker loop will exit. We have
+            # to do this directly, because if we do it through
+            # handle_message() that triggers shutdown logic that keeps
+            # the loop from working properly.
+            w.work_queue.put((None, None))
+            # We aren't using threads (and we trust that threads do
+            # work) so we just invoke the thread target ourselves to
+            # pretend.
+            w._thread_target()
+            meth.assert_called_once_with()

--- a/akanda/rug/test/unit/test_worker.py
+++ b/akanda/rug/test/unit/test_worker.py
@@ -1,6 +1,7 @@
 import mock
 import unittest2 as unittest
 
+from akanda.rug import event
 from akanda.rug import worker
 
 
@@ -8,18 +9,18 @@ class TestWorker(unittest.TestCase):
 
     def setUp(self):
         super(TestWorker, self).setUp()
-        self.w = worker.Worker()
+        self.w = worker.Worker(1)
 
-    @mock.patch('akanda.rug.state.Automaton')
+    @mock.patch('akanda.rug.tenant.TenantRouterManager')
     def test_new_router(self, automaton):
-        self.w.handle_message('1234', {'key': 'value'})
-        self.assertIn('1234', self.w.state_machines)
-        automaton.assert_called_with(
-            router_id='1234',
-            delete_callback=self.w._delete_router,
+        msg = event.Event(
+            tenant_id='1234',
+            router_id='5678',
+            crud=event.CREATE,
+            body={'key': 'value'},
         )
-
-    def test_delete_router(self):
-        self.w.state_machines['1234'] = mock.Mock()
-        self.w._delete_router('1234')
-        self.assertNotIn('1234', self.w.state_machines)
+        self.w.handle_message('1234', {'key': 'value'})
+        self.assertIn('1234', self.w.tenant_managers)
+        automaton.assert_called_with(
+            tenant_id='1234',
+        )

--- a/akanda/rug/worker.py
+++ b/akanda/rug/worker.py
@@ -75,6 +75,8 @@ class Worker(object):
         # FIXME(dhellmann): This could prevent us from deleting
         # routers that need to be deleted.
         self.work_queue = Queue.Queue()
+        for t in self.threads:
+            self.work_queue.put((None, None))
         # Shutdown all of the tenant router managers. The lock is
         # probably not necessary, since this should be running in the
         # same thread where new messages are being received (and
@@ -82,6 +84,9 @@ class Worker(object):
         with self.lock:
             for trm in self.tenant_managers.values():
                 trm.shutdown()
+        # Wait for our threads to finish
+        for t in self.threads:
+            t.join(timeout=1)
 
     def handle_message(self, target, message):
         """Callback to be used in main


### PR DESCRIPTION
Messages are delivered all the way down the stack to the state machine, and the state machine is dropped in the work queue to be processed when capacity is available. As discussed, this design depends on the state machine blocking while running update() but giving up control cooperatively at reasonable points by returning after significant updates are made.
