### PR TITLE
Trigger health checks

### DIFF
--- a/akanda/rug/health.py
+++ b/akanda/rug/health.py
@@ -1,0 +1,38 @@
+"""Periodic health check code.
+"""
+
+import logging
+import threading
+import time
+
+from akanda.rug import event
+
+LOG = logging.getLogger(__name__)
+
+
+def _health_inspector(period, scheduler):
+    """Runs in the thread.
+    """
+    while True:
+        time.sleep(period)
+        LOG.debug('waking up')
+        e = event.Event(
+            tenant_id='*',
+            router_id='*',
+            crud=event.POLL,
+            body={},
+        )
+        scheduler.handle_message('*', e)
+
+
+def start_inspector(period, scheduler):
+    """Start a health check thread.
+    """
+    t = threading.Thread(
+        target=_health_inspector,
+        args=(period, scheduler,),
+        name='HealthInspector',
+    )
+    t.setDaemon(True)
+    t.start()
+    return t

--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -6,6 +6,7 @@ import sys
 
 from oslo.config import cfg
 
+from akanda.rug import health
 from akanda.rug import notifications
 from akanda.rug import scheduler
 from akanda.rug import worker
@@ -78,7 +79,6 @@ def main(argv=sys.argv[1:]):
         name='NotificationListener',
     )
     notification_proc.start()
-    # notifications.listen(amqp_url, notification_queue)
 
     # Set up a factory to make Workers that know how many threads to
     # run.
@@ -93,6 +93,9 @@ def main(argv=sys.argv[1:]):
         num_workers=cfg.CONF.num_worker_processes,
         worker_factory=worker_factory,
     )
+
+    # Set up the periodic health check
+    health.start_inspector(cfg.CONF.health_check_period, sched)
 
     # Block the main process, copying messages from the notification
     # listener to the scheduler

--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -91,7 +91,7 @@ def main(argv=sys.argv[1:]):
     worker_factory = functools.partial(
         worker.Worker,
         num_threads=cfg.CONF.num_worker_threads,
-        notification_publisher=publisher,
+        notifier=publisher,
     )
 
     # Set up the scheduler that knows how to manage the routers and

--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -76,15 +76,22 @@ def main(argv=sys.argv[1:]):
     notification_proc = multiprocessing.Process(
         target=notifications.listen,
         args=(cfg.CONF.host, cfg.CONF.amqp_url, notification_queue,),
-        name='NotificationListener',
+        name='notification-listener',
     )
     notification_proc.start()
+
+    # Set up the notifications publisher
+    publisher = notifications.Publisher(
+        cfg.CONF.amqp_url,
+        topic='notifications.info',
+    )
 
     # Set up a factory to make Workers that know how many threads to
     # run.
     worker_factory = functools.partial(
         worker.Worker,
         num_threads=cfg.CONF.num_worker_threads,
+        notification_publisher=publisher,
     )
 
     # Set up the scheduler that knows how to manage the routers and

--- a/akanda/rug/notifications.py
+++ b/akanda/rug/notifications.py
@@ -227,10 +227,11 @@ class Publisher(object):
         LOG.debug('started %s', self._t.getName())
 
     def stop(self):
-        LOG.debug('stopping %s', self._t.getName())
-        self._q.put(None)
-        self._t.join(timeout=1)
-        self._t = None
+        if self._t:
+            LOG.debug('stopping %s', self._t.getName())
+            self._q.put(None)
+            self._t.join(timeout=1)
+            self._t = None
 
     def publish(self, incoming):
         msg = {}

--- a/akanda/rug/scheduler.py
+++ b/akanda/rug/scheduler.py
@@ -43,11 +43,15 @@ class Dispatcher(object):
     def __init__(self, workers):
         self.workers = workers
 
-    def pick_worker(self, target):
-        """Returns the worker that manages the target.
+    def pick_workers(self, target):
+        """Returns the workers that match the target.
         """
+        # If we get the wildcard target, send the message to all of
+        # the workers.
+        if target == '*':
+            return self.workers[:]
         idx = uuid.UUID(target).int % len(self.workers)
-        return self.workers[idx]
+        return [self.workers[idx]]
 
 
 class Scheduler(object):
@@ -109,5 +113,5 @@ class Scheduler(object):
         :param message: Dictionary full of data to send to the target.
         :type message: dict
         """
-        w = self.dispatcher.pick_worker(target)
-        w['queue'].put((target, message))
+        for w in self.dispatcher.pick_workers(target):
+            w['queue'].put((target, message))

--- a/akanda/rug/state.py
+++ b/akanda/rug/state.py
@@ -25,10 +25,11 @@ class Automaton(object):
 
     def update(self):
         "Called when the router config should be changed"
-        while not self.queue.empty():
-            message = self.queue.get()
+        while self.has_more_work():
+            message = self._queue.get()
             self.log.debug('update: %r', message)
             # TODO: Manage the router!
+            self._queue.task_done()
 
     def send_message(self, message):
         "Called when the worker put a message in the state machine queue"

--- a/akanda/rug/state.py
+++ b/akanda/rug/state.py
@@ -7,16 +7,22 @@ import Queue
 
 class Automaton(object):
 
-    def __init__(self, router_id, delete_callback):
+    def __init__(self, router_id, delete_callback, bandwidth_callback):
         """
         :param router_id: UUID of the router being managed
         :type router_id: str
         :param delete_callback: Invoked when the Automaton decides
                                 the router should be deleted.
         :type delete_callback: callable
+        :param bandwidth_callback: To be invoked when the Automaton
+                                   needs to report how much bandwidth
+                                   a router has used.
+        :type bandwidth_callback: callable taking router_id and bandwidth
+                                  info dict
         """
         self.router_id = router_id
         self.delete_callback = delete_callback
+        self.bandwidth_callback = bandwidth_callback
         self._queue = Queue.Queue()
         self.log = logging.getLogger(__name__ + '.' + router_id)
 

--- a/akanda/rug/tenant.py
+++ b/akanda/rug/tenant.py
@@ -16,9 +16,9 @@ class TenantRouterManager(object):
     """Keep track of the state machines for the routers for a given tenant.
     """
 
-    def __init__(self, tenant_id, notifier):
+    def __init__(self, tenant_id, notify_callback):
         self.tenant_id = tenant_id
-        self.notifier = notifier
+        self.notify = notify_callback
         self.state_machines = {}
         self.quantum = quantum.Quantum(cfg.CONF)
         self._default_router_id = None
@@ -50,7 +50,7 @@ class TenantRouterManager(object):
             'payload': dict((b.pop('name'), b) for b in bandwidth),
             'router_id': router_id,
         }
-        self.notifier.publish(msg)
+        self.notify(msg)
 
     def get_state_machines(self, message):
         """Return the state machines and the queue for sending it messages for

--- a/akanda/rug/tenant.py
+++ b/akanda/rug/tenant.py
@@ -39,8 +39,8 @@ class TenantRouterManager(object):
                     'Failed to shutdown state machine for %s' % rid
                 )
 
-    def get_state_machine(self, message):
-        """Return the state machine and the queue for sending it messages for
+    def get_state_machines(self, message):
+        """Return the state machines and the queue for sending it messages for
         the router being addressed by the message.
         """
         router_id = message.router_id
@@ -50,6 +50,12 @@ class TenantRouterManager(object):
                 router = self.quantum.get_router_for_tenant(message.tenant_id)
                 self._default_router_id = router.id
             router_id = self._default_router_id
+
+        elif router_id == '*':
+            # All of our routers
+            return list(self.state_machines.values())
+
+        # An individual router by its id.
         if router_id not in self.state_machines:
             def deleter():
                 self._delete_router(router_id)
@@ -59,4 +65,4 @@ class TenantRouterManager(object):
             )
             self.state_machines[router_id] = sm
         sm = self.state_machines[router_id]
-        return sm
+        return [sm]

--- a/akanda/rug/test/unit/test_notifications.py
+++ b/akanda/rug/test/unit/test_notifications.py
@@ -1,6 +1,3 @@
-import Queue
-import time
-
 import mock
 
 import unittest2 as unittest

--- a/akanda/rug/test/unit/test_notifications.py
+++ b/akanda/rug/test/unit/test_notifications.py
@@ -1,3 +1,7 @@
+import Queue
+
+import mock
+
 import unittest2 as unittest
 
 from akanda.rug import event
@@ -204,3 +208,24 @@ class TestGetCRUD(unittest.TestCase):
 
         e = notifications._make_event_from_message(msg)
         self.assertEqual(e.router_id, u'f95fb32d-0072-4675-b4bd-61d829a46aca')
+
+    def test_notification_akanda(self):
+        e = self._test_notification('akanda.bandwidth.used')
+        self.assertIs(None, e)
+
+
+class TestSend(unittest.TestCase):
+
+    @mock.patch('kombu.connection.BrokerConnection')
+    @mock.patch('kombu.entity.Exchange')
+    @mock.patch('kombu.Producer')
+    def test_break_on_none(self, producer_cls, exchange, broker):
+        # Set up the producer "instance" so we can test how it is
+        # used.
+        producer = mock.Mock()
+        producer_cls.return_value = producer
+        notifier = notifications.Publisher('url', 'topic')
+        notifier.publish('message here')
+        notifier.start()
+        notifier.stop()
+        producer.publish.assert_called_with('message here')

--- a/akanda/rug/test/unit/test_notifications.py
+++ b/akanda/rug/test/unit/test_notifications.py
@@ -225,23 +225,22 @@ class TestSend(unittest.TestCase):
         producer_cls.return_value = self.producer
         self.notifier = notifications.Publisher('url', 'quantum', 'topic')
         self.notifier.start()
+        self.addCleanup(self.notifier.stop)
 
-    def tearDown(self):
-        if self.notifier:
-            self.notifier.stop()
-        super(TestSend, self).tearDown()
+    # def tearDown(self):
+    #     if self.notifier:
+    #         self.notifier.stop()
+    #     super(TestSend, self).tearDown()
 
     def test_payload(self):
         self.notifier.publish({'payload': 'message here'})
         self.notifier.stop()  # flushes the queue
-        self.notifier = None
         msg = self.messages[0]
         self.assertEqual(msg['payload'], 'message here')
 
     def test_context(self):
         self.notifier.publish({'payload': 'message here'})
         self.notifier.stop()  # flushes the queue
-        self.notifier = None
         msg = self.messages[0]
         self.assertIn('_context_tenant', msg)
 
@@ -249,6 +248,5 @@ class TestSend(unittest.TestCase):
         self.notifier.publish({'payload': 'message here'})
         self.notifier.publish({'payload': 'message here'})
         self.notifier.stop()  # flushes the queue
-        self.notifier = None
         msg1, msg2 = self.messages
         self.assertNotEqual(msg1['_unique_id'], msg2['_unique_id'])

--- a/akanda/rug/test/unit/test_notifications.py
+++ b/akanda/rug/test/unit/test_notifications.py
@@ -223,7 +223,7 @@ class TestSend(unittest.TestCase):
         self.producer = mock.Mock()
         self.producer.publish.side_effect = self.messages.append
         producer_cls.return_value = self.producer
-        self.notifier = notifications.Publisher('url', 'topic')
+        self.notifier = notifications.Publisher('url', 'quantum', 'topic')
         self.notifier.start()
 
     def tearDown(self):

--- a/akanda/rug/test/unit/test_scheduler.py
+++ b/akanda/rug/test/unit/test_scheduler.py
@@ -47,7 +47,14 @@ class TestDispatcher(unittest.TestCase):
         for i in range(len(self.workers)):
             router_id = self._mk_uuid(i)
             self.assertEqual(
-                i,
-                self.d.pick_worker(router_id),
+                [i],
+                self.d.pick_workers(router_id),
                 'Incorrect index for %s' % router_id,
             )
+
+    def test_wildcard(self):
+        self.assertEqual(
+            self.workers,
+            self.d.pick_workers('*'),
+            'wildcard dispatch failed',
+        )

--- a/akanda/rug/test/unit/test_state.py
+++ b/akanda/rug/test/unit/test_state.py
@@ -23,3 +23,8 @@ class TestAutomaton(unittest.TestCase):
         with mock.patch.object(self.sm._queue, 'empty') as meth:
             meth.return_value = False
             self.assertTrue(self.sm.has_more_work())
+
+    def test_update_no_work(self):
+        with mock.patch.object(self.sm._queue, 'empty') as meth:
+            self.sm.update()
+            meth.assert_called_with()

--- a/akanda/rug/test/unit/test_state.py
+++ b/akanda/rug/test/unit/test_state.py
@@ -11,6 +11,7 @@ class TestAutomaton(unittest.TestCase):
         self.sm = state.Automaton(
             router_id='9306bbd8-f3cc-11e2-bd68-080027e60b25',
             delete_callback=mock.Mock(),
+            bandwidth_callback=None,
         )
 
     def test_send_message(self):

--- a/akanda/rug/test/unit/test_tenant.py
+++ b/akanda/rug/test/unit/test_tenant.py
@@ -13,7 +13,7 @@ class TestTenantRouterManager(unittest.TestCase):
         self.notifier = mock.Mock()
         self.trm = tenant.TenantRouterManager(
             '1234',
-            notifier=self.notifier,
+            notify_callback=self.notifier,
         )
         # Establish a fake default router for the tenant for tests
         # that try to use it. We mock out the class above to avoid
@@ -138,7 +138,7 @@ class TestTenantRouterManager(unittest.TestCase):
 
     def test_report_bandwidth(self):
         notifications = []
-        self.notifier.publish.side_effect = notifications.append
+        self.notifier.side_effect = notifications.append
         self.trm._report_bandwidth(
             '5678',
             [{'name': 'a',

--- a/akanda/rug/test/unit/test_tenant.py
+++ b/akanda/rug/test/unit/test_tenant.py
@@ -28,7 +28,7 @@ class TestTenantRouterManager(unittest.TestCase):
             crud=event.CREATE,
             body={'key': 'value'},
         )
-        sm = self.trm.get_state_machine(msg)
+        sm = self.trm.get_state_machines(msg)[0]
         self.assertEqual(sm.router_id, '5678')
         self.assertIn('5678', self.trm.state_machines)
 
@@ -39,9 +39,20 @@ class TestTenantRouterManager(unittest.TestCase):
             crud=event.CREATE,
             body={'key': 'value'},
         )
-        sm = self.trm.get_state_machine(msg)
+        sm = self.trm.get_state_machines(msg)[0]
         self.assertEqual(sm.router_id, self.default_router.id)
         self.assertIn(self.default_router.id, self.trm.state_machines)
+
+    def test_all_routers(self):
+        self.trm.state_machines = dict((str(i), i) for i in range(5))
+        msg = event.Event(
+            tenant_id='1234',
+            router_id='*',
+            crud=event.CREATE,
+            body={'key': 'value'},
+        )
+        sms = self.trm.get_state_machines(msg)
+        self.assertEqual(5, len(sms))
 
     @mock.patch('akanda.rug.state.Automaton')
     def test_existing_router(self, automaton):
@@ -57,9 +68,9 @@ class TestTenantRouterManager(unittest.TestCase):
             body={'key': 'value'},
         )
         # First time creates...
-        sm1 = self.trm.get_state_machine(msg)
+        sm1 = self.trm.get_state_machines(msg)[0]
         # Second time should return the same objects...
-        sm2 = self.trm.get_state_machine(msg)
+        sm2 = self.trm.get_state_machines(msg)[0]
         self.assertIs(sm1, sm2)
         self.assertIs(sm1.queue, sm2.queue)
 
@@ -79,7 +90,7 @@ class TestTenantRouterManager(unittest.TestCase):
                 body={'key': 'value'},
             )
             # First time creates...
-            sm1 = self.trm.get_state_machine(msg)
+            sm1 = self.trm.get_state_machines(msg)[0]
             sms[router_id] = sm1
         # Second time should return the same objects...
         msg = event.Event(
@@ -88,7 +99,7 @@ class TestTenantRouterManager(unittest.TestCase):
             crud=event.CREATE,
             body={'key': 'value'},
         )
-        sm2 = self.trm.get_state_machine(msg)
+        sm2 = self.trm.get_state_machines(msg)[0]
         self.assertIs(sm2, sms['5678'])
 
     def test_delete_router(self):
@@ -116,7 +127,7 @@ class TestTenantRouterManager(unittest.TestCase):
             crud=event.CREATE,
             body={'key': 'value'},
         )
-        sm = self.trm.get_state_machine(msg)
+        sm = self.trm.get_state_machines(msg)[0]
         self.assertIn('5678', self.trm.state_machines)
         sm.delete_callback()
         self.assertNotIn('5678', self.trm.state_machines)

--- a/akanda/rug/test/unit/test_worker.py
+++ b/akanda/rug/test/unit/test_worker.py
@@ -12,7 +12,7 @@ class TestWorkerCreatingRouter(unittest.TestCase):
     @mock.patch('akanda.rug.api.quantum.Quantum')
     def setUp(self, quantum):
         super(TestWorkerCreatingRouter, self).setUp()
-        self.w = worker.Worker(0)
+        self.w = worker.Worker(0, mock.Mock())
         self.tenant_id = '1234'
         self.router_id = '5678'
         self.msg = event.Event(
@@ -46,7 +46,7 @@ class TestWorkerWildcardMessages(unittest.TestCase):
     @mock.patch('akanda.rug.api.quantum.Quantum')
     def setUp(self, quantum):
         super(TestWorkerWildcardMessages, self).setUp()
-        self.w = worker.Worker(0)
+        self.w = worker.Worker(0, mock.Mock())
         # Create some tenants
         for msg in [
                 event.Event(
@@ -77,14 +77,14 @@ class TestWorkerShutdown(unittest.TestCase):
 
     @mock.patch('akanda.rug.api.quantum.Quantum')
     def test_shutdown_on_null_message(self, quantum):
-        self.w = worker.Worker(0)
+        self.w = worker.Worker(0, mock.Mock())
         with mock.patch.object(self.w, '_shutdown') as meth:
             self.w.handle_message(None, None)
             meth.assert_called_once_with()
 
     @mock.patch('akanda.rug.api.quantum.Quantum')
     def test_stop_threads(self, quantum):
-        self.w = worker.Worker(1)
+        self.w = worker.Worker(1, mock.Mock())
         original_queue = self.w.work_queue
         self.assertTrue(self.w._keep_going)
         self.w._shutdown()
@@ -108,7 +108,7 @@ class TestWorkerUpdateStateMachine(unittest.TestCase):
 
     @mock.patch('akanda.rug.api.quantum.Quantum')
     def test(self, quantum):
-        w = worker.Worker(0)
+        w = worker.Worker(0, mock.Mock())
         tenant_id = '1234'
         router_id = '5678'
         msg = event.Event(

--- a/akanda/rug/test/unit/test_worker.py
+++ b/akanda/rug/test/unit/test_worker.py
@@ -97,7 +97,7 @@ class TestWorkerShutdown(unittest.TestCase):
     @mock.patch('kombu.Producer')
     @mock.patch('akanda.rug.api.quantum.Quantum')
     def test_stop_threads_notifier(self, quantum, producer, exchange, broker):
-        notifier = notifications.Publisher('url', 'topic')
+        notifier = notifications.Publisher('url', 'quantum', 'topic')
         self.w = worker.Worker(0, notifier)
         self.assertTrue(self.w.notifier._t)
         self.w._shutdown()

--- a/akanda/rug/test/unit/test_worker.py
+++ b/akanda/rug/test/unit/test_worker.py
@@ -1,5 +1,3 @@
-import Queue
-
 import mock
 
 import unittest2 as unittest

--- a/akanda/rug/test/unit/test_worker.py
+++ b/akanda/rug/test/unit/test_worker.py
@@ -1,8 +1,11 @@
+import Queue
+
 import mock
 
 import unittest2 as unittest
 
 from akanda.rug import event
+from akanda.rug import notifications
 from akanda.rug import worker
 
 
@@ -90,6 +93,17 @@ class TestWorkerShutdown(unittest.TestCase):
         self.assertFalse(self.w._keep_going)
         new_queue = self.w.work_queue
         self.assertIsNot(original_queue, new_queue)
+
+    @mock.patch('kombu.connection.BrokerConnection')
+    @mock.patch('kombu.entity.Exchange')
+    @mock.patch('kombu.Producer')
+    @mock.patch('akanda.rug.api.quantum.Quantum')
+    def test_stop_threads_notifier(self, quantum, producer, exchange, broker):
+        notifier = notifications.Publisher('url', 'topic')
+        self.w = worker.Worker(0, notifier)
+        self.assertTrue(self.w.notifier._t)
+        self.w._shutdown()
+        self.assertFalse(self.w.notifier._t)
 
 
 class TestWorkerUpdateStateMachine(unittest.TestCase):

--- a/akanda/rug/worker.py
+++ b/akanda/rug/worker.py
@@ -18,7 +18,7 @@ class Worker(object):
     method of an instance of this class instead of a simple function.
     """
 
-    def __init__(self, num_threads, notifier=None):
+    def __init__(self, num_threads, notifier):
         self.work_queue = Queue.Queue()
         self.lock = threading.Lock()
         self._keep_going = True
@@ -34,10 +34,10 @@ class Worker(object):
         for t in self.threads:
             t.setDaemon(True)
             t.start()
-        self.outgoing_notifications = Queue.Queue()
         self.notifier = notifier
-        if notifier:
-            self.notifier.start()
+        # The notifier needs to be started here to ensure that it
+        # happens inside the worker process and not the parent.
+        self.notifier.start()
 
     def _thread_target(self):
         """This method runs in each worker thread.

--- a/akanda/rug/worker.py
+++ b/akanda/rug/worker.py
@@ -105,7 +105,7 @@ class Worker(object):
             LOG.debug('creating tenant manager for %s', target)
             self.tenant_managers[target] = tenant.TenantRouterManager(
                 tenant_id=target,
-                notifier=self.notifier,
+                notify_callback=self.notifier.publish,
             )
         return [self.tenant_managers[target]]
 

--- a/akanda/rug/worker.py
+++ b/akanda/rug/worker.py
@@ -105,6 +105,7 @@ class Worker(object):
             LOG.debug('creating tenant manager for %s', target)
             self.tenant_managers[target] = tenant.TenantRouterManager(
                 tenant_id=target,
+                notifier=self.notifier,
             )
         return [self.tenant_managers[target]]
 


### PR DESCRIPTION
Add a thread to periodically deliver a health-check message
to all existing routers by using a wildcard address. This
assumes that the Automaton will properly clean up after
itself if it gets a health check and decides its router
should have been deleted already.

Change-Id: I09eddba578d2c1308f7c01257a65100829f90c40
