### PR TITLE
Pre-populate workers with existing router on startup

### DIFF
--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -9,6 +9,7 @@ from oslo.config import cfg
 from akanda.rug import health
 from akanda.rug import notifications
 from akanda.rug import scheduler
+from akanda.rug import populate
 from akanda.rug import worker
 
 LOG = logging.getLogger(__name__)
@@ -119,6 +120,9 @@ def main(argv=sys.argv[1:]):
         num_workers=cfg.CONF.num_worker_processes,
         worker_factory=worker_factory,
     )
+
+    # Prepopulate the workers with existing routers on startup
+    populate.pre_populate_workers(sched)
 
     # Set up the periodic health check
     health.start_inspector(cfg.CONF.health_check_period, sched)

--- a/akanda/rug/populate.py
+++ b/akanda/rug/populate.py
@@ -1,0 +1,71 @@
+"""Populate the workers with the existing routers
+"""
+
+import logging
+import threading
+import time
+
+from oslo.config import cfg
+from quantumclient.common import exceptions as q_exceptions
+
+from akanda.rug import event
+from akanda.rug.api import quantum
+
+LOG = logging.getLogger(__name__)
+
+
+def _pre_populate_workers(scheduler):
+    """Fetch the existing routers from quantum.
+
+    Wait for quantum to return the list of the existing routers.
+    Pause up to max_sleep seconds between each attempt and ignore
+    quantum client exceptions.
+
+
+    """
+    nap_time = 1
+    max_sleep = 15
+
+    quantum_client = quantum.Quantum(cfg.CONF)
+
+    while True:
+        try:
+            quantum_routers = quantum_client.get_routers()
+            break
+        except (q_exceptions.Unauthorized, q_exceptions.Forbidden) as err:
+            LOG.warning('PrePopulateWorkers thread failed: %s', err)
+            return
+        except Exception as err:
+            LOG.warning(
+                '%s: %s' % ('Could not fetch routers from quantum', err))
+            LOG.warning('sleeping %s seconds before retrying' % nap_time)
+            time.sleep(nap_time)
+            # FIXME(rods): should we get max_sleep from the config file?
+            nap_time = min(nap_time * 2, max_sleep)
+
+    LOG.debug('Start pre-populating the workers with %d fetched routers',
+              len(quantum_routers))
+
+    for router in quantum_routers:
+        message = event.Event(
+            tenant_id=router.tenant_id,
+            router_id=router.router_id,
+            crud=event.POLL,
+            body={}
+        )
+        scheduler.handle_message(router.tenant_id, message)
+
+
+def pre_populate_workers(scheduler):
+    """Start the pre-populating task
+    """
+
+    t = threading.Thread(
+        target=_pre_populate_workers,
+        args=(scheduler,),
+        name='PrePopulateWorkers'
+    )
+
+    t.setDaemon(True)
+    t.start()
+    return t

--- a/akanda/rug/test/unit/test_populate.py
+++ b/akanda/rug/test/unit/test_populate.py
@@ -1,0 +1,116 @@
+import mock
+import unittest2 as unittest
+
+from quantumclient.common import exceptions as q_exceptions
+
+from akanda.rug import populate
+from akanda.rug.api import quantum
+
+
+class TestPrePopulateWorkers(unittest.TestCase):
+
+    @mock.patch('akanda.rug.api.quantum.Quantum')
+    def test_retry_loop(self, mocked_quantum_api):
+        quantum_client = mock.Mock()
+        returned_value = [Exception, []]
+        quantum_client.get_routers.side_effect = returned_value
+
+        mocked_quantum_api.return_value = quantum_client
+
+        sched = mock.Mock()
+        populate._pre_populate_workers(sched)
+        self.assertEqual(
+            quantum_client.get_routers.call_args_list,
+            [mock.call() for value in xrange(len(returned_value))]
+        )
+        self.assertEqual(
+            quantum_client.get_routers.call_count,
+            len(returned_value)
+        )
+
+    def _exit_loop_bad_auth(self, mocked_quantum_api, log, exc):
+        quantum_client = mock.Mock()
+        quantum_client.get_routers.side_effect = exc
+        mocked_quantum_api.return_value = quantum_client
+        sched = mock.Mock()
+        populate._pre_populate_workers(sched)
+        log.warning.assert_called_once_with(
+            'PrePopulateWorkers thread failed: %s',
+            mock.ANY
+        )
+
+    @mock.patch('akanda.rug.populate.LOG')
+    @mock.patch('akanda.rug.api.quantum.Quantum')
+    def test_exit_loop_unauthorized(self, mocked_quantum_api, log):
+        exc = q_exceptions.Unauthorized
+        self._exit_loop_bad_auth(mocked_quantum_api, log, exc)
+
+    @mock.patch('akanda.rug.populate.LOG')
+    @mock.patch('akanda.rug.api.quantum.Quantum')
+    def test_exit_loop_forbidden(self, mocked_quantum_api, log):
+        exc = q_exceptions.Forbidden
+        self._exit_loop_bad_auth(mocked_quantum_api, log, exc)
+
+    @mock.patch('akanda.rug.populate.LOG')
+    @mock.patch('akanda.rug.api.quantum.Quantum')
+    def test_retry_loop_logging(self, mocked_quantum_api, log):
+        quantum_client = mock.Mock()
+        message = mock.Mock(tenant_id='1', router_id='2')
+        returned_value = [
+            quantum.client.exceptions.QuantumClientException,
+            [message]
+        ]
+        quantum_client.get_routers.side_effect = returned_value
+
+        mocked_quantum_api.return_value = quantum_client
+
+        sched = mock.Mock()
+        populate._pre_populate_workers(sched)
+        expected = [
+            mock.call.warning(u'Could not fetch routers from quantum: '
+                              'An unknown exception occurred.'),
+            mock.call.warning('sleeping 1 seconds before retrying'),
+            mock.call.debug('Start pre-populating the workers '
+                            'with %d fetched routers', 1)
+        ]
+        self.assertEqual(log.mock_calls, expected)
+
+    @mock.patch('akanda.rug.event.Event')
+    @mock.patch('akanda.rug.api.quantum.Quantum')
+    def test_scheduler_handle_message(self, mocked_quantum_api, event):
+        quantum_client = mock.Mock()
+        message1 = {'tenant_id': '1', 'router_id': '2',
+                    'body': {}, 'crud': 'poll'}
+        message2 = {'tenant_id': '3', 'router_id': '4',
+                    'body': {}, 'crud': 'poll'}
+        return_value = [mock.Mock(**message1), mock.Mock(** message2)]
+        quantum_client.get_routers.return_value = return_value
+
+        sched = mock.Mock()
+        mocked_quantum_api.return_value = quantum_client
+        populate._pre_populate_workers(sched)
+
+        self.assertEqual(sched.handle_message.call_count, len(return_value))
+        expected = [
+            mock.call(message1['tenant_id'], mock.ANY),
+            mock.call(message2['tenant_id'], mock.ANY)
+        ]
+        self.assertEqual(sched.handle_message.call_args_list, expected)
+
+        self.assertEqual(event.call_count, 2)
+        expected = [mock.call(**message1), mock.call(**message2)]
+        self.assertEqual(event.call_args_list, expected)
+
+    @mock.patch('threading.Thread')
+    def test_pre_populate_workers(self, thread):
+        sched = mock.Mock()
+        t = populate.pre_populate_workers(sched)
+        thread.assert_called_once_with(
+            target=populate._pre_populate_workers,
+            args=(sched,),
+            name='PrePopulateWorkers'
+        )
+        self.assertEqual(
+            t.mock_calls,
+            [mock.call.setDaemon(True), mock.call.start()]
+        )


### PR DESCRIPTION
DHC-1378

Create a new thread that runs at startup and fetch
existing routers from quantum pushing healt_check message
in the scheduler queue for every router.

Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
