### PR TITLE
Fix reference to exception class in tests

### DIFF
--- a/akanda/rug/test/unit/test_populate.py
+++ b/akanda/rug/test/unit/test_populate.py
@@ -57,7 +57,7 @@ class TestPrePopulateWorkers(unittest.TestCase):
         quantum_client = mock.Mock()
         message = mock.Mock(tenant_id='1', router_id='2')
         returned_value = [
-            quantum.client.exceptions.QuantumClientException,
+            q_exceptions.QuantumClientException,
             [message]
         ]
         quantum_client.get_routers.side_effect = returned_value


### PR DESCRIPTION
Use the already imported exceptions module from the quantum client
instead of going through our API module to get there.

Change-Id: Icec885a779bfb8db729d0414f293ece12ec8e553
