### PR TITLE
The _get_management_address method needs a Router object as param not a router id

### DIFF
--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -30,7 +30,7 @@ class VmManager(object):
     def update_state(self, silent=False):
         self._ensure_cache()
 
-        addr = _get_management_address(self.router_id)
+        addr = _get_management_address(self.logical_router)
         for i in xrange(MAX_RETRIES):
             try:
                 if router_api.is_alive(addr, cfg.CONF.akanda_mgt_service_port):


### PR DESCRIPTION
The _get_management_address method needs a Router object as param not a router id

Change-Id: If49ad1d3179796790e50f077fc558755eabf0d60
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
