### PR TITLE
Manage cases where network events don't need router management

### DIFF
--- a/akanda/rug/tenant.py
+++ b/akanda/rug/tenant.py
@@ -61,6 +61,11 @@ class TenantRouterManager(object):
             if self._default_router_id is None:
                 LOG.debug('looking up router for tenant %s', message.tenant_id)
                 router = self.quantum.get_router_for_tenant(message.tenant_id)
+                # Not all network related events need router managemant,
+                # in some cases there could be not router to manage.
+                # e.g. a port created on the mgt or external networks
+                if not router:
+                    return []
                 self._default_router_id = router.id
             router_id = self._default_router_id
 

--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -30,7 +30,7 @@ class VmManager(object):
     def update_state(self, silent=False):
         self._ensure_cache()
 
-        addr = _get_management_address(self.logical_router)
+        addr = _get_management_address(self._logical_router)
         for i in xrange(MAX_RETRIES):
             try:
                 if router_api.is_alive(addr, cfg.CONF.akanda_mgt_service_port):


### PR DESCRIPTION
Not all network related events need router management and
in some cases there could be not router to manage.
(e.g. a port created on the mgt or external network in the
service tenant)

Change-Id: Ifa44c337ff7aa362c64698e06f2664518ca8d9e7
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
