### PR TITLE
Fix the updating loops

### DIFF
--- a/akanda/rug/state.py
+++ b/akanda/rug/state.py
@@ -213,4 +213,4 @@ class Automaton(object):
 
     def has_more_work(self):
         "Called to check if there are more messages in the state machine queue"
-        return bool(self._queue)
+        return (not isinstance(self.state, Exit)) and bool(self._queue)


### PR DESCRIPTION
DHC-1517

When a router is deleted, the state-machine is removed from the
tenant-manager dict but if there are still tasks in the
its queue, the state-machine is going to be queued
again resulting in an infinte updating loop.

Change-Id: I390984a6fe95de2332cc414070cd2023cfa4c4a5
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
