### PR TITLE
remove references to quantumclient in populate

### DIFF
--- a/akanda/rug/populate.py
+++ b/akanda/rug/populate.py
@@ -6,7 +6,7 @@ import threading
 import time
 
 from oslo.config import cfg
-from quantumclient.common import exceptions as q_exceptions
+from neutronclient.common import exceptions as q_exceptions
 
 from akanda.rug import event
 from akanda.rug.api import quantum

--- a/akanda/rug/test/unit/test_populate.py
+++ b/akanda/rug/test/unit/test_populate.py
@@ -1,7 +1,7 @@
 import mock
 import unittest2 as unittest
 
-from quantumclient.common import exceptions as q_exceptions
+from neutronclient.common import exceptions as q_exceptions
 
 from akanda.rug import populate
 


### PR DESCRIPTION
These were missed in a cleanup the other day
