### PR TITLE
The RUG is not waiting the retry_delay time while it checks if the router is alive

### DIFF
--- a/akanda/rug/api/akanda_client.py
+++ b/akanda/rug/api/akanda_client.py
@@ -22,13 +22,10 @@ def _get_proxyless_session():
 
 def is_alive(host, port):
     path = AKANDA_BASE_PATH + 'firewall/labels'
-    try:
-        s = _get_proxyless_session()
-        r = s.get(_mgt_url(host, port, path), timeout=1.0)
-        if r.status_code == 200:
-            return True
-    except:
-        pass
+    s = _get_proxyless_session()
+    r = s.get(_mgt_url(host, port, path), timeout=1.0)
+    if r.status_code == 200:
+        return True
     return False
 
 

--- a/akanda/rug/test/unit/api/test_akanda_router.py
+++ b/akanda/rug/test/unit/api/test_akanda_router.py
@@ -40,15 +40,6 @@ class TestAkandaClient(unittest.TestCase):
             timeout=1.0
         )
 
-    def test_is_alive_exception(self):
-        self.mock_get.side_effect = Exception
-
-        self.assertFalse(akanda_client.is_alive('fe80::2', 5000))
-        self.mock_get.assert_called_once_with(
-            'http://[fe80::2]:5000/v1/firewall/labels',
-            timeout=1.0
-        )
-
     def test_get_interfaces(self):
         self.mock_get.return_value.status_code = 200
         self.mock_get.return_value.json.return_value = {


### PR DESCRIPTION
DHC-1656

The is_alive method is catching all the exceptions and returning
a boolean while the update_state method expects an exceptions to
delay the new request

Change-Id: I565aa160ef7b6b4eaeca5ee9dedc6ab9459f52eb
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
