### PR TITLE
RUG should wait the retry_delay time checking if a router is alive

### DIFF
--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -34,19 +34,17 @@ class VmManager(object):
 
         addr = _get_management_address(self.router_obj)
         for i in xrange(cfg.CONF.max_retries):
-            try:
-                if router_api.is_alive(addr, cfg.CONF.akanda_mgt_service_port):
-                    if self.state != CONFIGURED:
-                        self.state = UP
-                    break
-            except:
-                if not silent:
-                    self.log.exception(
-                        'Alive check failed. Attempt %d of %d',
-                        i,
-                        cfg.CONF.max_retries
-                    )
-                time.sleep(cfg.CONF.retry_delay)
+            if router_api.is_alive(addr, cfg.CONF.akanda_mgt_service_port):
+                if self.state != CONFIGURED:
+                    self.state = UP
+                break
+            if not silent:
+                self.log.debug(
+                    'Alive check failed. Attempt %d of %d',
+                    i,
+                    cfg.CONF.max_retries
+                )
+            time.sleep(cfg.CONF.retry_delay)
         else:
             self.state = DOWN
 


### PR DESCRIPTION
DHC-1656

The is_alive method catch all the exceptions returning a boolean
while the update_state method expects an exception to delay the
new request. This change fix the issue removing the try/except
block and delaying the new request based on the boolean returned
from the is_alive method.

Change-Id: I454123dd42f4b875c02afc3c714b520f8830d159
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
