### PR TITLE
Reduce the number of REST clients in use

### DIFF
--- a/akanda/rug/test/unit/test_worker.py
+++ b/akanda/rug/test/unit/test_worker.py
@@ -12,17 +12,20 @@ from akanda.rug import vm_manager
 from akanda.rug import worker
 
 
-class TestWorkerCreatingRouter(unittest.TestCase):
+class TestCreatingRouter(unittest.TestCase):
 
-    @mock.patch('akanda.rug.api.quantum.Quantum')
-    def setUp(self, quantum):
-        super(TestWorkerCreatingRouter, self).setUp()
+    def setUp(self):
+        super(TestCreatingRouter, self).setUp()
 
         self.conf = mock.patch.object(vm_manager.cfg, 'CONF').start()
         self.conf.boot_timeout = 1
         self.conf.akanda_mgt_service_port = 5000
         self.conf.max_retries = 3
         self.conf.management_prefix = 'fdca:3ba5:a17a:acda::/64'
+
+        mock.patch('akanda.rug.worker.nova').start()
+        mock.patch('akanda.rug.worker.quantum').start()
+
         self.addCleanup(mock.patch.stopall)
 
         self.w = worker.Worker(0, mock.Mock())
@@ -38,7 +41,7 @@ class TestWorkerCreatingRouter(unittest.TestCase):
 
     def tearDown(self):
         self.w._shutdown()
-        super(TestWorkerCreatingRouter, self).tearDown()
+        super(TestCreatingRouter, self).tearDown()
 
     def test_in_tenant_managers(self):
         self.assertIn(self.tenant_id, self.w.tenant_managers)
@@ -47,24 +50,27 @@ class TestWorkerCreatingRouter(unittest.TestCase):
 
     def test_message_enqueued(self):
         trm = self.w.tenant_managers[self.tenant_id]
-        sm = trm.get_state_machines(self.msg)[0]
+        sm = trm.get_state_machines(self.msg, worker.WorkerContext())[0]
         self.assertEqual(1, len(sm._queue))
 
     def test_being_updated_set(self):
         self.assertIn(self.router_id, self.w.being_updated)
 
 
-class TestWorkerWildcardMessages(unittest.TestCase):
+class TestWildcardMessages(unittest.TestCase):
 
-    @mock.patch('akanda.rug.api.quantum.Quantum')
-    def setUp(self, quantum):
-        super(TestWorkerWildcardMessages, self).setUp()
+    def setUp(self):
+        super(TestWildcardMessages, self).setUp()
 
         self.conf = mock.patch.object(vm_manager.cfg, 'CONF').start()
         self.conf.boot_timeout = 1
         self.conf.akanda_mgt_service_port = 5000
         self.conf.max_retries = 3
         self.conf.management_prefix = 'fdca:3ba5:a17a:acda::/64'
+
+        mock.patch('akanda.rug.worker.nova').start()
+        mock.patch('akanda.rug.worker.quantum').start()
+
         self.addCleanup(mock.patch.stopall)
 
         self.w = worker.Worker(0, mock.Mock())
@@ -86,7 +92,7 @@ class TestWorkerWildcardMessages(unittest.TestCase):
 
     def tearDown(self):
         self.w._shutdown()
-        super(TestWorkerWildcardMessages, self).tearDown()
+        super(TestWildcardMessages, self).tearDown()
 
     def test_wildcard_to_all(self):
         trms = self.w._get_trms('*')
@@ -94,17 +100,21 @@ class TestWorkerWildcardMessages(unittest.TestCase):
         self.assertEqual(['1234', '5678'], ids)
 
 
-class TestWorkerShutdown(unittest.TestCase):
+class TestShutdown(unittest.TestCase):
 
-    @mock.patch('akanda.rug.api.quantum.Quantum')
-    def test_shutdown_on_null_message(self, quantum):
+    def setUp(self):
+        super(TestShutdown, self).setUp()
+        mock.patch('akanda.rug.worker.nova').start()
+        mock.patch('akanda.rug.worker.quantum').start()
+        self.addCleanup(mock.patch.stopall)
+
+    def test_shutdown_on_null_message(self):
         self.w = worker.Worker(0, mock.Mock())
         with mock.patch.object(self.w, '_shutdown') as meth:
             self.w.handle_message(None, None)
             meth.assert_called_once_with()
 
-    @mock.patch('akanda.rug.api.quantum.Quantum')
-    def test_stop_threads(self, quantum):
+    def test_stop_threads(self):
         self.w = worker.Worker(1, mock.Mock())
         original_queue = self.w.work_queue
         self.assertTrue(self.w._keep_going)
@@ -116,8 +126,7 @@ class TestWorkerShutdown(unittest.TestCase):
     @mock.patch('kombu.connection.BrokerConnection')
     @mock.patch('kombu.entity.Exchange')
     @mock.patch('kombu.Producer')
-    @mock.patch('akanda.rug.api.quantum.Quantum')
-    def test_stop_threads_notifier(self, quantum, producer, exchange, broker):
+    def test_stop_threads_notifier(self, producer, exchange, broker):
         notifier = notifications.Publisher('url', 'quantum', 'topic')
         self.w = worker.Worker(0, notifier)
         self.assertTrue(self.w.notifier._t)
@@ -125,21 +134,25 @@ class TestWorkerShutdown(unittest.TestCase):
         self.assertFalse(self.w.notifier._t)
 
 
-class TestWorkerUpdateStateMachine(unittest.TestCase):
+class TestUpdateStateMachine(unittest.TestCase):
 
-    @mock.patch('akanda.rug.api.quantum.Quantum')
-    def setUp(self, quantum):
-        super(TestWorkerUpdateStateMachine, self).setUp()
+    def setUp(self):
+        super(TestUpdateStateMachine, self).setUp()
 
         self.conf = mock.patch.object(vm_manager.cfg, 'CONF').start()
         self.conf.boot_timeout = 1
         self.conf.akanda_mgt_service_port = 5000
         self.conf.max_retries = 3
         self.conf.management_prefix = 'fdca:3ba5:a17a:acda::/64'
+
+        mock.patch('akanda.rug.worker.nova').start()
+        mock.patch('akanda.rug.worker.quantum').start()
+
+        self.worker_context = worker.WorkerContext()
+
         self.addCleanup(mock.patch.stopall)
 
-    @mock.patch('akanda.rug.api.quantum.Quantum')
-    def test(self, quantum):
+    def test(self):
         w = worker.Worker(0, mock.Mock())
         tenant_id = '1234'
         router_id = '5678'
@@ -152,7 +165,7 @@ class TestWorkerUpdateStateMachine(unittest.TestCase):
         # Create the router manager and state machine so we can
         # replace the update() method with a mock.
         trm = w._get_trms(tenant_id)[0]
-        sm = trm.get_state_machines(msg)[0]
+        sm = trm.get_state_machines(msg, self.worker_context)[0]
         with mock.patch.object(sm, 'update') as meth:
             w.handle_message(tenant_id, msg)
             # Add a null message so the worker loop will exit. We have
@@ -163,11 +176,17 @@ class TestWorkerUpdateStateMachine(unittest.TestCase):
             # We aren't using threads (and we trust that threads do
             # work) so we just invoke the thread target ourselves to
             # pretend.
-            w._thread_target()
-            meth.assert_called_once_with()
+            used_context = w._thread_target()
+            meth.assert_called_once_with(used_context)
 
 
-class TestWorkerReportStatus(unittest.TestCase):
+class TestReportStatus(unittest.TestCase):
+
+    def setUp(self):
+        super(TestReportStatus, self).setUp()
+        mock.patch('akanda.rug.worker.nova').start()
+        mock.patch('akanda.rug.worker.quantum').start()
+        self.addCleanup(mock.patch.stopall)
 
     def test_report_status_dispatched(self):
         self.w = worker.Worker(0, mock.Mock())
@@ -188,48 +207,48 @@ class TestWorkerReportStatus(unittest.TestCase):
         )
 
 
-class TestWorkerDebugRouters(unittest.TestCase):
+class TestDebugRouters(unittest.TestCase):
 
-    @mock.patch('akanda.rug.api.quantum.Quantum')
-    def setUp(self, quantum):
-        super(TestWorkerDebugRouters, self).setUp()
+    def setUp(self):
+        super(TestDebugRouters, self).setUp()
 
         self.conf = mock.patch.object(vm_manager.cfg, 'CONF').start()
         self.conf.boot_timeout = 1
         self.conf.akanda_mgt_service_port = 5000
         self.conf.max_retries = 3
         self.conf.management_prefix = 'fdca:3ba5:a17a:acda::/64'
+
+        mock.patch('akanda.rug.worker.nova').start()
+        mock.patch('akanda.rug.worker.quantum').start()
+
+        self.w = worker.Worker(0, mock.Mock())
+
         self.addCleanup(mock.patch.stopall)
 
     def testNoDebugs(self):
-        w = worker.Worker(0, mock.Mock())
-        self.assertEqual(set(), w._debug_routers)
+        self.assertEqual(set(), self.w._debug_routers)
 
     def testWithDebugs(self):
-        w = worker.Worker(0, mock.Mock())
-        w.handle_message(
+        self.w.handle_message(
             '*',
             event.Event('*', '', event.COMMAND,
                         {'payload': {'command': commands.ROUTER_DEBUG,
                                      'router_id': 'this-router-id'}}),
         )
-        self.assertEqual(set(['this-router-id']), w._debug_routers)
+        self.assertEqual(set(['this-router-id']), self.w._debug_routers)
 
     def testManage(self):
-        w = worker.Worker(0, mock.Mock())
-        w._debug_routers = set(['this-router-id'])
-        w.handle_message(
+        self.w._debug_routers = set(['this-router-id'])
+        self.w.handle_message(
             '*',
             event.Event('*', '', event.COMMAND,
                         {'payload': {'command': commands.ROUTER_MANAGE,
                                      'router_id': 'this-router-id'}}),
         )
-        self.assertEqual(set(), w._debug_routers)
+        self.assertEqual(set(), self.w._debug_routers)
 
-    @mock.patch('akanda.rug.api.quantum.Quantum')
-    def testDebugging(self, quantum):
-        w = worker.Worker(0, mock.Mock())
-        w._debug_routers = set(['5678'])
+    def testDebugging(self):
+        self.w._debug_routers = set(['5678'])
 
         tenant_id = '1234'
         router_id = '5678'
@@ -241,26 +260,29 @@ class TestWorkerDebugRouters(unittest.TestCase):
         )
         # Create the router manager and state machine so we can
         # replace the send_message() method with a mock.
-        trm = w._get_trms(tenant_id)[0]
-        sm = trm.get_state_machines(msg)[0]
+        trm = self.w._get_trms(tenant_id)[0]
+        sm = trm.get_state_machines(msg, worker.WorkerContext())[0]
         with mock.patch.object(sm, 'send_message') as meth:
             # The router id is being ignored, so the send_message()
             # method shouldn't ever be invoked.
             meth.side_effect = AssertionError('send_message was called')
-            w.handle_message(tenant_id, msg)
+            self.w.handle_message(tenant_id, msg)
 
 
-class TestWorkerIgnoreRouters(unittest.TestCase):
+class TestIgnoreRouters(unittest.TestCase):
 
-    @mock.patch('akanda.rug.api.quantum.Quantum')
-    def setUp(self, quantum):
-        super(TestWorkerIgnoreRouters, self).setUp()
+    def setUp(self):
+        super(TestIgnoreRouters, self).setUp()
 
         self.conf = mock.patch.object(vm_manager.cfg, 'CONF').start()
         self.conf.boot_timeout = 1
         self.conf.akanda_mgt_service_port = 5000
         self.conf.max_retries = 3
         self.conf.management_prefix = 'fdca:3ba5:a17a:acda::/64'
+
+        mock.patch('akanda.rug.worker.nova').start()
+        mock.patch('akanda.rug.worker.quantum').start()
+
         self.addCleanup(mock.patch.stopall)
 
     def testNoIgnorePath(self):
@@ -296,8 +318,7 @@ class TestWorkerIgnoreRouters(unittest.TestCase):
         )
         self.assertEqual(set(), w._debug_routers)
 
-    @mock.patch('akanda.rug.api.quantum.Quantum')
-    def testIgnoring(self, quantum):
+    def testIgnoring(self):
         tmpdir = tempfile.mkdtemp()
         fullname = os.path.join(tmpdir, '5678')
         with open(fullname, 'a'):
@@ -316,7 +337,7 @@ class TestWorkerIgnoreRouters(unittest.TestCase):
         # Create the router manager and state machine so we can
         # replace the send_message() method with a mock.
         trm = w._get_trms(tenant_id)[0]
-        sm = trm.get_state_machines(msg)[0]
+        sm = trm.get_state_machines(msg, worker.WorkerContext())[0]
         with mock.patch.object(sm, 'send_message') as meth:
             # The router id is being ignored, so the send_message()
             # method shouldn't ever be invoked.
@@ -324,48 +345,48 @@ class TestWorkerIgnoreRouters(unittest.TestCase):
             w.handle_message(tenant_id, msg)
 
 
-class TestWorkerDebugTenants(unittest.TestCase):
+class TestDebugTenants(unittest.TestCase):
 
-    @mock.patch('akanda.rug.api.quantum.Quantum')
-    def setUp(self, quantum):
-        super(TestWorkerDebugTenants, self).setUp()
+    def setUp(self):
+        super(TestDebugTenants, self).setUp()
 
         self.conf = mock.patch.object(vm_manager.cfg, 'CONF').start()
         self.conf.boot_timeout = 1
         self.conf.akanda_mgt_service_port = 5000
         self.conf.max_retries = 3
         self.conf.management_prefix = 'fdca:3ba5:a17a:acda::/64'
+
+        mock.patch('akanda.rug.worker.nova').start()
+        mock.patch('akanda.rug.worker.quantum').start()
+
+        self.w = worker.Worker(0, mock.Mock())
+
         self.addCleanup(mock.patch.stopall)
 
     def testNoDebugs(self):
-        w = worker.Worker(0, mock.Mock())
-        self.assertEqual(set(), w._debug_tenants)
+        self.assertEqual(set(), self.w._debug_tenants)
 
     def testWithDebugs(self):
-        w = worker.Worker(0, mock.Mock())
-        w.handle_message(
+        self.w.handle_message(
             '*',
             event.Event('*', '', event.COMMAND,
                         {'payload': {'command': commands.TENANT_DEBUG,
                                      'tenant_id': 'this-tenant-id'}}),
         )
-        self.assertEqual(set(['this-tenant-id']), w._debug_tenants)
+        self.assertEqual(set(['this-tenant-id']), self.w._debug_tenants)
 
     def testManage(self):
-        w = worker.Worker(0, mock.Mock())
-        w._debug_tenants = set(['this-tenant-id'])
-        w.handle_message(
+        self.w._debug_tenants = set(['this-tenant-id'])
+        self.w.handle_message(
             '*',
             event.Event('*', '', event.COMMAND,
                         {'payload': {'command': commands.TENANT_MANAGE,
                                      'tenant_id': 'this-tenant-id'}}),
         )
-        self.assertEqual(set(), w._debug_tenants)
+        self.assertEqual(set(), self.w._debug_tenants)
 
-    @mock.patch('akanda.rug.api.quantum.Quantum')
-    def testDebugging(self, quantum):
-        w = worker.Worker(0, mock.Mock())
-        w._debug_tenants = set(['1234'])
+    def testDebugging(self):
+        self.w._debug_tenants = set(['1234'])
 
         tenant_id = '1234'
         router_id = '5678'
@@ -377,10 +398,10 @@ class TestWorkerDebugTenants(unittest.TestCase):
         )
         # Create the router manager and state machine so we can
         # replace the send_message() method with a mock.
-        trm = w._get_trms(tenant_id)[0]
-        sm = trm.get_state_machines(msg)[0]
+        trm = self.w._get_trms(tenant_id)[0]
+        sm = trm.get_state_machines(msg, worker.WorkerContext())[0]
         with mock.patch.object(sm, 'send_message') as meth:
             # The tenant id is being ignored, so the send_message()
             # method shouldn't ever be invoked.
             meth.side_effect = AssertionError('send_message was called')
-            w.handle_message(tenant_id, msg)
+            self.w.handle_message(tenant_id, msg)


### PR DESCRIPTION
Maintain a "worker context" for each thread with REST clients for nova
and neutron, and pass them to the Automaton and VmManager classes when
a thread needs to do some work with them.

Change-Id: I3d286969b73eacfead2d748415bb060dd78e9e09
