### PR TITLE
Pre-emptively clean up router ports before rebooting.

### DIFF
--- a/akanda/rug/api/nova.py
+++ b/akanda/rug/api/nova.py
@@ -13,10 +13,8 @@ class Nova(object):
             region_name=conf.auth_region)
 
     def create_router_instance(self, router):
-        ports = [router.management_port, router.external_port]
-        ports.extend(router.internal_ports)
         nics = [{'net-id': p.network_id, 'v4-fixed-ip': '', 'port-id': p.id}
-                for p in ports]
+                for p in router.ports]
 
         # Sometimes a timing problem makes Nova try to create an akanda
         # instance using some ports that haven't been cleaned up yet from

--- a/akanda/rug/api/quantum.py
+++ b/akanda/rug/api/quantum.py
@@ -473,6 +473,9 @@ class Quantum(object):
             device_name = driver.get_device_name(port)
             driver.unplug(device_name)
 
+    def clear_device_id(self, port):
+        self.api_client.update_port(port.id, {'port': {'device_id': ''}})
+
 
 def get_local_service_ip(conf):
     mgt_net = netaddr.IPNetwork(conf.management_prefix)

--- a/akanda/rug/api/quantum.py
+++ b/akanda/rug/api/quantum.py
@@ -1,3 +1,4 @@
+import itertools
 import socket
 import time
 import uuid
@@ -104,6 +105,13 @@ class Subnet(object):
             d['enable_dhcp'],
             d['dns_nameservers'],
             d['host_routes'])
+
+    @property
+    def ports(self):
+        return itertools.chain(
+            [self.management_port, self.external_port],
+            self.internal_ports
+        )
 
 
 class Port(object):

--- a/akanda/rug/test/unit/api/test_nova_wrapper.py
+++ b/akanda/rug/test/unit/api/test_nova_wrapper.py
@@ -32,7 +32,8 @@ fake_router = FakeModel(
     tenant_id='tenant_id',
     external_port=fake_ext_port,
     management_port=fake_mgt_port,
-    internal_ports=[fake_int_port])
+    internal_ports=[fake_int_port],
+    ports=[fake_mgt_port, fake_ext_port, fake_int_port])
 
 
 class FakeConf:

--- a/akanda/rug/test/unit/api/test_quantum_wrapper.py
+++ b/akanda/rug/test/unit/api/test_quantum_wrapper.py
@@ -223,3 +223,11 @@ class TestQuantumWrapper(unittest.TestCase):
         quantum_wrapper.purge_management_interface()
         driver.get_device_name.assert_called_once()
         driver.unplug.assert_called_once()
+
+    def test_clear_device_id(self):
+        quantum_wrapper = quantum.Quantum(mock.Mock())
+        quantum_wrapper.api_client.update_port = mock.Mock()
+        quantum_wrapper.clear_device_id(mock.Mock(id='PORT1'))
+        quantum_wrapper.api_client.update_port.assert_called_once_with(
+            'PORT1', {'port': {'device_id': ''}}
+        )

--- a/akanda/rug/test/unit/test_vmmanager.py
+++ b/akanda/rug/test/unit/test_vmmanager.py
@@ -92,8 +92,8 @@ class TestVmManager(unittest.TestCase):
         rtr.id = 'ROUTER1'
         rtr.management_port = None
         rtr.external_port = None
-        rtr.internal_ports = mock.MagicMock()
-        rtr.internal_ports.__iter__.return_value = []
+        rtr.ports = mock.MagicMock()
+        rtr.ports.__iter__.return_value = []
         self.vm_mgr.boot(self.ctx)
         self.assertEqual(self.vm_mgr.state, vm_manager.UP)
         self.ctx.nova_client.reboot_router_instance.assert_called_once_with(
@@ -108,8 +108,8 @@ class TestVmManager(unittest.TestCase):
         rtr.id = 'ROUTER1'
         rtr.management_port = None
         rtr.external_port = None
-        rtr.internal_ports = mock.MagicMock()
-        rtr.internal_ports.__iter__.return_value = []
+        rtr.ports = mock.MagicMock()
+        rtr.ports.__iter__.return_value = []
         self.vm_mgr.boot(self.ctx)
         self.assertEqual(self.vm_mgr.state, vm_manager.DOWN)
         self.ctx.nova_client.reboot_router_instance.assert_called_once_with(
@@ -133,8 +133,9 @@ class TestVmManager(unittest.TestCase):
         instance.id = 'INSTANCE1'
         rtr.management_port = management_port
         rtr.external_port = external_port
-        rtr.internal_ports = mock.MagicMock()
-        rtr.internal_ports.__iter__.return_value = [internal_port]
+        rtr.ports = mock.MagicMock()
+        rtr.ports.__iter__.return_value = [management_port, external_port,
+                                           internal_port]
         self.vm_mgr.boot(self.ctx)
         self.assertEqual(self.vm_mgr.state, vm_manager.UP)
         self.ctx.nova_client.reboot_router_instance.assert_called_once_with(

--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -1,5 +1,6 @@
 import netaddr
 import time
+import itertools
 
 from oslo.config import cfg
 
@@ -59,7 +60,22 @@ class VmManager(object):
         self.state = DOWN
 
         try:
-            worker_context.nova_client.reboot_router_instance(self.router_obj)
+            # In the event that the current akanda instance isn't deleted
+            # cleanly (which we've seen in certain circumstances, like
+            # hypervisor failures), be proactive and attempt to clean up the
+            # router ports manually.  This helps avoid a situation where the
+            # rug repeatedly attempts to plug stale router ports into the newly
+            # created akanda instance (and fails).
+            router = self.router_obj
+            instance = worker_context.nova_client.get_instance(router)
+            if instance is not None:
+                for p in itertools.chain(
+                    [router.management_port, router.external_port],
+                    router.internal_ports
+                ):
+                    if p.device_id == instance.id:
+                        worker_context.neutron.clear_device_id(p)
+            worker_context.nova_client.reboot_router_instance(router)
         except:
             self.log.exception('Router failed to start boot')
             return

--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -1,6 +1,5 @@
 import netaddr
 import time
-import itertools
 
 from oslo.config import cfg
 
@@ -69,10 +68,7 @@ class VmManager(object):
             router = self.router_obj
             instance = worker_context.nova_client.get_instance(router)
             if instance is not None:
-                for p in itertools.chain(
-                    [router.management_port, router.external_port],
-                    router.internal_ports
-                ):
+                for p in router.ports:
                     if p.device_id == instance.id:
                         worker_context.neutron.clear_device_id(p)
             worker_context.nova_client.reboot_router_instance(router)


### PR DESCRIPTION
In the event that an akanda instance isn't deleted
cleanly (which we've seen in certain circumstances, like
hypervisor failures), be proactive and attempt to clean up the
router ports manually.  This helps avoid a situation where the
rug repeatedly attempts to plug stale router ports into the newly
created akanda instance (and fails).
