### PR TITLE
Move ports property definition to the right class

### DIFF
--- a/akanda/rug/api/quantum.py
+++ b/akanda/rug/api/quantum.py
@@ -77,6 +77,13 @@ class Router(object):
             floating_ips=fips
         )
 
+    @property
+    def ports(self):
+        return itertools.chain(
+            [self.management_port, self.external_port],
+            self.internal_ports
+        )
+
 
 class Subnet(object):
     def __init__(self, id_, name, tenant_id, network_id, ip_version, cidr,
@@ -105,13 +112,6 @@ class Subnet(object):
             d['enable_dhcp'],
             d['dns_nameservers'],
             d['host_routes'])
-
-    @property
-    def ports(self):
-        return itertools.chain(
-            [self.management_port, self.external_port],
-            self.internal_ports
-        )
 
 
 class Port(object):

--- a/akanda/rug/test/unit/api/test_quantum_wrapper.py
+++ b/akanda/rug/test/unit/api/test_quantum_wrapper.py
@@ -16,6 +16,7 @@ class TestQuantumModels(unittest.TestCase):
         self.assertEqual(r.external_port, 'ext')
         self.assertEqual(r.management_port, 'mgt')
         self.assertEqual(r.internal_ports, ['int'])
+        self.assertEqual(set(['ext', 'mgt', 'int']), set(r.ports))
 
     def test_router_from_dict(self):
         p = {


### PR DESCRIPTION
The new ports property was added to the Subnet class
instead of the Router class.

Change-Id: Ibcd0cd90eb2beb3d1bb0c77747c255b628f7a6ba
