### PR TITLE
Unpin version of iso8601 package

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,7 +5,7 @@ coverage
 mock>=0.8.0
 pep8
 eventlet==0.12.1
-iso8601==0.1.4
+iso8601
 python-novaclient
 WebOb==1.2.3
 mox==0.5.3


### PR DESCRIPTION
The python-neutronclient package requires a newer version
of iso8601, so unpin our version to allow the right version
to be installed.

Change-Id: I2f8b1a4b0602df6c7c435700653e21cfc63527ef
