### PR TITLE
Be less clever about avoiding work.

### DIFF
--- a/akanda/rug/test/unit/test_worker.py
+++ b/akanda/rug/test/unit/test_worker.py
@@ -53,9 +53,6 @@ class TestCreatingRouter(unittest.TestCase):
         sm = trm.get_state_machines(self.msg, worker.WorkerContext())[0]
         self.assertEqual(1, len(sm._queue))
 
-    def test_being_updated_set(self):
-        self.assertIn(self.router_id, self.w.being_updated)
-
 
 class TestWildcardMessages(unittest.TestCase):
 


### PR DESCRIPTION
We used to try to keep track of which routers had updates pending so
when new updates came in we could avoid growing the work queue with
trials for the router that would never be processed. This, it turns out,
is a Bad Idea. Don't do it.

Change-Id: Ia078953e9dfa548230c119ffb540a72152711112
