### PR TITLE
tighten up log line format

### DIFF
--- a/akanda/rug/scheduler.py
+++ b/akanda/rug/scheduler.py
@@ -82,7 +82,7 @@ class Scheduler(object):
                     'inq': wq,
                     'worker_factory': worker_factory,
                 },
-                name='worker-%02d' % i,
+                name='p%02d' % i,
             )
             worker.start()
             self.workers.append({

--- a/akanda/rug/state.py
+++ b/akanda/rug/state.py
@@ -17,6 +17,13 @@ class State(object):
     def __init__(self, log):
         self.log = log
 
+    @property
+    def name(self):
+        return self.__class__.__name__
+
+    def __str__(self):
+        return self.name
+
     def execute(self, action, vm, worker_context):
         return action
 
@@ -209,16 +216,14 @@ class Automaton(object):
                     elif isinstance(self.state, ReadStats):
                         additional_args = (self.bandwidth_callback,)
 
-                    self.log.debug('executing %r for %r %s',
-                                   self.action, self.vm, self)
+                    self.log.debug('execute(%s)', self.action)
                     self.action = self.state.execute(
                         self.action,
                         self.vm,
                         worker_context,
                         *additional_args
                     )
-                    self.log.debug('execute for %r returned next action %r',
-                                   self.vm, self.action)
+                    self.log.debug('execute -> %s', self.action)
                 except:
                     self.log.exception(
                         'execute() failed for action: %s',
@@ -231,8 +236,7 @@ class Automaton(object):
                     self.vm,
                     worker_context,
                 )
-                self.log.debug('%s transitioned from %s to %s',
-                               self.vm, old_state, self.state)
+                self.log.debug('state %s -> %s', old_state, self.state)
 
                 if isinstance(self.state, CalcAction):
                     return  # yield

--- a/akanda/rug/worker.py
+++ b/akanda/rug/worker.py
@@ -46,7 +46,7 @@ class Worker(object):
         self._context = WorkerContext()
         self.threads = [
             threading.Thread(
-                name='worker-thread-%02d' % i,
+                name='t%02d' % i,
                 target=self._thread_target,
             )
             for i in xrange(num_threads)


### PR DESCRIPTION
We had a lot of really long log lines, sometimes including object ids
instead of simpler messages. This change tightens those up so it is
easier to follow what is happening in the log.

Change-Id: Id46182e01abd28f46a2377dae236367e1578bbc1
