### PR TITLE
Add rug-ctl command to reload config

### DIFF
--- a/akanda/rug/cli/config.py
+++ b/akanda/rug/cli/config.py
@@ -1,0 +1,20 @@
+"""Commands related to the application configuration
+"""
+import logging
+
+from akanda.rug import commands
+from akanda.rug.cli import message
+
+
+class ConfigReload(message.MessageSending):
+    """reload the configuration file(s)"""
+
+    log = logging.getLogger(__name__)
+
+    def make_message(self, parsed_args):
+        self.log.info(
+            'sending config reload instruction',
+        )
+        return {
+            'command': commands.CONFIG_RELOAD,
+        }

--- a/akanda/rug/commands.py
+++ b/akanda/rug/commands.py
@@ -13,3 +13,6 @@ ROUTER_MANAGE = 'router-manage'
 # Expects a 'tenant_id' argument in the payload with the UUID of the tenant
 TENANT_DEBUG = 'tenant-debug'
 TENANT_MANAGE = 'tenant-manage'
+
+# Configuration commands
+CONFIG_RELOAD = 'config-reload'

--- a/akanda/rug/worker.py
+++ b/akanda/rug/worker.py
@@ -221,6 +221,14 @@ class Worker(object):
             except KeyError:
                 pass
 
+        elif instructions['command'] == commands.CONFIG_RELOAD:
+            try:
+                cfg.CONF()
+            except Exception:
+                LOG.exception('Could not reload configuration')
+            else:
+                cfg.CONF.log_opt_values(LOG, logging.INFO)
+
         else:
             LOG.warn('unrecognized command: %s', instructions)
 
@@ -281,6 +289,7 @@ class Worker(object):
         self._router_locks[sm.router_id].release()
 
     def report_status(self):
+        cfg.CONF.log_opt_values(LOG, logging.INFO)
         LOG.info(
             'Number of state machines in work queue: %d',
             self.work_queue.qsize()

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ console_scripts =
     akanda-debug-router=akanda.rug.debug:debug_one_router
     rug-ctl=akanda.rug.cli.main:main
 akanda.rug.cli =
+    config reload=akanda.rug.cli.config:ConfigReload
     router debug=akanda.rug.cli.router:RouterDebug
     router manage=akanda.rug.cli.router:RouterManage
     tenant debug=akanda.rug.cli.tenant:TenantDebug


### PR DESCRIPTION
Add a command to have the worker reload the configuration file(s). This will
be useful when we automatically deploy new router images, since we can change
the running RUG without restarting it and losing any work that is happening
at the time.

Change-Id: I08628b1292e0e5a26dc3382c790dd41a806716bb
