### PR TITLE
Perform an initial config PUT on boot to test "aliveness" of the router.

### DIFF
--- a/akanda/rug/api/akanda_client.py
+++ b/akanda/rug/api/akanda_client.py
@@ -24,7 +24,7 @@ def is_alive(host, port):
     path = AKANDA_BASE_PATH + 'firewall/labels'
     try:
         s = _get_proxyless_session()
-        r = s.get(_mgt_url(host, port, path), timeout=1.0)
+        r = s.get(_mgt_url(host, port, path), timeout=3.0)
         if r.status_code == 200:
             return True
     except:

--- a/akanda/rug/test/unit/api/test_akanda_router.py
+++ b/akanda/rug/test/unit/api/test_akanda_router.py
@@ -28,7 +28,7 @@ class TestAkandaClient(unittest.TestCase):
         self.assertTrue(akanda_client.is_alive('fe80::2', 5000))
         self.mock_get.assert_called_once_with(
             'http://[fe80::2]:5000/v1/firewall/labels',
-            timeout=1.0
+            timeout=3.0
         )
 
     def test_is_alive_bad_status(self):
@@ -37,7 +37,7 @@ class TestAkandaClient(unittest.TestCase):
         self.assertFalse(akanda_client.is_alive('fe80::2', 5000))
         self.mock_get.assert_called_once_with(
             'http://[fe80::2]:5000/v1/firewall/labels',
-            timeout=1.0
+            timeout=3.0
         )
 
     def test_is_alive_exception(self):
@@ -46,7 +46,7 @@ class TestAkandaClient(unittest.TestCase):
         self.assertFalse(akanda_client.is_alive('fe80::2', 5000))
         self.mock_get.assert_called_once_with(
             'http://[fe80::2]:5000/v1/firewall/labels',
-            timeout=1.0
+            timeout=3.0
         )
 
     def test_get_interfaces(self):


### PR DESCRIPTION
I'd also like to augment this in _another_ pull request by making the aliveness test smarter.  This, however, will require additional changes to the appliance.
