### PR TITLE
Log a warning for a router that is badly backed up

### DIFF
--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -111,6 +111,12 @@ def register_and_load_opts():
             help='Directory to scan for routers to ignore for debugging',
         ),
 
+        cfg.IntOpt(
+            'queue_warning_threshold',
+            default=100,
+            help='warn if the event backlog for a tenant exceeds this value',
+        )
+
     ])
 
     cfg.CONF.register_opts(metadata.metadata_opts)
@@ -221,6 +227,7 @@ def main(argv=sys.argv[1:]):
         num_threads=cfg.CONF.num_worker_threads,
         notifier=publisher,
         ignore_directory=cfg.CONF.ignored_router_directory,
+        queue_warning_threshold=cfg.CONF.queue_warning_threshold,
     )
 
     # Set up the scheduler that knows how to manage the routers and

--- a/akanda/rug/tenant.py
+++ b/akanda/rug/tenant.py
@@ -52,9 +52,10 @@ class TenantRouterManager(object):
     """Keep track of the state machines for the routers for a given tenant.
     """
 
-    def __init__(self, tenant_id, notify_callback):
+    def __init__(self, tenant_id, notify_callback, queue_warning_threshold):
         self.tenant_id = tenant_id
         self.notify = notify_callback
+        self._queue_warning_threshold = queue_warning_threshold
         self.state_machines = RouterContainer()
         self._default_router_id = None
 
@@ -132,6 +133,7 @@ class TenantRouterManager(object):
                 delete_callback=deleter,
                 bandwidth_callback=self._report_bandwidth,
                 worker_context=worker_context,
+                queue_warning_threshold=self._queue_warning_threshold,
             )
             self.state_machines[router_id] = sm
             state_machines = [sm]

--- a/akanda/rug/test/unit/test_tenant.py
+++ b/akanda/rug/test/unit/test_tenant.py
@@ -17,6 +17,7 @@ class TestTenantRouterManager(unittest.TestCase):
         self.trm = tenant.TenantRouterManager(
             '1234',
             notify_callback=self.notifier,
+            queue_warning_threshold=10,
         )
         # Establish a fake default router for the tenant for tests
         # that try to use it. We mock out the class above to avoid
@@ -54,7 +55,7 @@ class TestTenantRouterManager(unittest.TestCase):
     def test_all_routers(self):
         self.trm.state_machines.state_machines = {
             str(i): state.Automaton(str(i), '1234',
-                                    None, None, None)
+                                    None, None, None, 5)
             for i in range(5)
         }
         msg = event.Event(

--- a/akanda/rug/worker.py
+++ b/akanda/rug/worker.py
@@ -35,8 +35,13 @@ class Worker(object):
     method of an instance of this class instead of a simple function.
     """
 
-    def __init__(self, num_threads, notifier, ignore_directory=None):
+    def __init__(self,
+                 num_threads,
+                 notifier,
+                 ignore_directory=None,
+                 queue_warning_threshold=100):
         self._ignore_directory = ignore_directory
+        self._queue_warning_threshold = queue_warning_threshold
         self.work_queue = Queue.Queue()
         self.lock = threading.Lock()
         self._keep_going = True
@@ -175,6 +180,7 @@ class Worker(object):
             self.tenant_managers[target] = tenant.TenantRouterManager(
                 tenant_id=target,
                 notify_callback=self.notifier.publish,
+                queue_warning_threshold=self._queue_warning_threshold,
             )
         return [self.tenant_managers[target]]
 


### PR DESCRIPTION
When the work queue for a router becomes very long, log warnings as new items
are added instead of debug messages.

Change-Id: I80c7107c369b7e9207a78b4e4c9147388c637ad2
