### PR TITLE
Add rug-ctl router rebuild command

### DIFF
--- a/akanda/rug/cli/message.py
+++ b/akanda/rug/cli/message.py
@@ -31,6 +31,7 @@ class MessageSending(command.Command):
             'event_type': 'akanda.rug.command',
             'payload': payload,
         }
+        self.log.debug('sending %r', msg)
         with notifications.Sender(
                 amqp_url=self.app.rug_ini.amqp_url,
                 exchange_name=self.app.rug_ini.outgoing_notifications_exchange,

--- a/akanda/rug/cli/router.py
+++ b/akanda/rug/cli/router.py
@@ -41,10 +41,7 @@ class RouterManage(_RouterCmd):
     _COMMAND = commands.ROUTER_MANAGE
 
 
-class RouterUpdate(_RouterCmd):
-    """force-update a router"""
-
-    _COMMAND = commands.ROUTER_UPDATE
+class _TenantRouterCmd(_RouterCmd):
 
     def get_parser(self, prog_name):
         # Bypass the direct base class to let us put the tenant id
@@ -60,22 +57,26 @@ class RouterUpdate(_RouterCmd):
         return p
 
     def make_message(self, parsed_args):
-        tenant_id = parsed_args.tenant_id.replace('-', '')
-        tenant_id = '-'.join([
-            tenant_id[:8],
-            tenant_id[8:12],
-            tenant_id[12:16],
-            tenant_id[16:20],
-            tenant_id[20:],
-        ])
         self.log.info(
             'sending %s instruction for tenant %r, router with uuid %r',
             self._COMMAND,
-            tenant_id,
+            parsed_args.tenant_id,
             parsed_args.router_id,
         )
         return {
             'command': self._COMMAND,
             'router_id': parsed_args.router_id,
-            'tenant_id': tenant_id,
+            'tenant_id': parsed_args.tenant_id,
         }
+
+
+class RouterUpdate(_TenantRouterCmd):
+    """force-update a router"""
+
+    _COMMAND = commands.ROUTER_UPDATE
+
+
+class RouterRebuild(_TenantRouterCmd):
+    """force-rebuild a router"""
+
+    _COMMAND = commands.ROUTER_REBUILD

--- a/akanda/rug/commands.py
+++ b/akanda/rug/commands.py
@@ -12,6 +12,8 @@ ROUTER_DEBUG = 'router-debug'
 ROUTER_MANAGE = 'router-manage'
 # Send an updated config to the router whether it is needed or not
 ROUTER_UPDATE = 'router-update'
+# Rebuild a router from scratch
+ROUTER_REBUILD = 'router-rebuild'
 
 # Put a tenant in debug/manage mode
 # Expects a 'tenant_id' argument in the payload with the UUID of the tenant

--- a/akanda/rug/event.py
+++ b/akanda/rug/event.py
@@ -14,3 +14,4 @@ UPDATE = 'update'
 DELETE = 'delete'
 POLL = 'poll'
 COMMAND = 'command'  # an external command to be processed
+REBUILD = 'rebuild'

--- a/akanda/rug/tenant.py
+++ b/akanda/rug/tenant.py
@@ -93,6 +93,7 @@ class TenantRouterManager(object):
         """
         router_id = message.router_id
         if not router_id:
+            LOG.debug('looking for router for %s', message.tenant_id)
             if self._default_router_id is None:
                 # TODO(mark): handle muliple router lookup
                 router = worker_context.neutron.get_router_for_tenant(
@@ -106,6 +107,7 @@ class TenantRouterManager(object):
                     return []
                 self._default_router_id = router.id
             router_id = self._default_router_id
+            LOG.debug('using router id %s', router_id)
 
         # Ignore messages to deleted routers.
         if self.state_machines.has_been_deleted(router_id):

--- a/akanda/rug/test/unit/test_worker.py
+++ b/akanda/rug/test/unit/test_worker.py
@@ -29,8 +29,8 @@ class TestCreatingRouter(unittest.TestCase):
         self.addCleanup(mock.patch.stopall)
 
         self.w = worker.Worker(0, mock.Mock())
-        self.tenant_id = '1234'
-        self.router_id = '5678'
+        self.tenant_id = '98dd9c41-d3ac-4fd6-8927-567afa0b8fc3'
+        self.router_id = 'ac194fc5-f317-412e-8611-fb290629f624'
         self.msg = event.Event(
             tenant_id=self.tenant_id,
             router_id=self.router_id,
@@ -74,13 +74,13 @@ class TestWildcardMessages(unittest.TestCase):
         # Create some tenants
         for msg in [
                 event.Event(
-                    tenant_id='1234',
+                    tenant_id='98dd9c41-d3ac-4fd6-8927-567afa0b8fc3',
                     router_id='ABCD',
                     crud=event.CREATE,
                     body={'key': 'value'},
                 ),
                 event.Event(
-                    tenant_id='5678',
+                    tenant_id='ac194fc5-f317-412e-8611-fb290629f624',
                     router_id='EFGH',
                     crud=event.CREATE,
                     body={'key': 'value'},
@@ -94,7 +94,9 @@ class TestWildcardMessages(unittest.TestCase):
     def test_wildcard_to_all(self):
         trms = self.w._get_trms('*')
         ids = sorted(trm.tenant_id for trm in trms)
-        self.assertEqual(['1234', '5678'], ids)
+        self.assertEqual(['98dd9c41-d3ac-4fd6-8927-567afa0b8fc3',
+                          'ac194fc5-f317-412e-8611-fb290629f624'],
+                         ids)
 
 
 class TestShutdown(unittest.TestCase):
@@ -151,8 +153,8 @@ class TestUpdateStateMachine(unittest.TestCase):
 
     def test(self):
         w = worker.Worker(0, mock.Mock())
-        tenant_id = '1234'
-        router_id = '5678'
+        tenant_id = '98dd9c41-d3ac-4fd6-8927-567afa0b8fc3'
+        router_id = 'ac194fc5-f317-412e-8611-fb290629f624'
         msg = event.Event(
             tenant_id=tenant_id,
             router_id=router_id,
@@ -247,10 +249,10 @@ class TestDebugRouters(unittest.TestCase):
         self.assertEqual(set(), self.w._debug_routers)
 
     def testDebugging(self):
-        self.w._debug_routers = set(['5678'])
+        self.w._debug_routers = set(['ac194fc5-f317-412e-8611-fb290629f624'])
 
-        tenant_id = '1234'
-        router_id = '5678'
+        tenant_id = '98dd9c41-d3ac-4fd6-8927-567afa0b8fc3'
+        router_id = 'ac194fc5-f317-412e-8611-fb290629f624'
         msg = event.Event(
             tenant_id=tenant_id,
             router_id=router_id,
@@ -319,14 +321,14 @@ class TestIgnoreRouters(unittest.TestCase):
 
     def testIgnoring(self):
         tmpdir = tempfile.mkdtemp()
-        fullname = os.path.join(tmpdir, '5678')
+        fullname = os.path.join(tmpdir, 'ac194fc5-f317-412e-8611-fb290629f624')
         with open(fullname, 'a'):
             os.utime(fullname, None)
         self.addCleanup(lambda: os.unlink(fullname) and os.rmdir(tmpdir))
         w = worker.Worker(0, mock.Mock(), ignore_directory=tmpdir)
 
-        tenant_id = '1234'
-        router_id = '5678'
+        tenant_id = '98dd9c41-d3ac-4fd6-8927-567afa0b8fc3'
+        router_id = 'ac194fc5-f317-412e-8611-fb290629f624'
         msg = event.Event(
             tenant_id=tenant_id,
             router_id=router_id,
@@ -385,10 +387,10 @@ class TestDebugTenants(unittest.TestCase):
         self.assertEqual(set(), self.w._debug_tenants)
 
     def testDebugging(self):
-        self.w._debug_tenants = set(['1234'])
+        self.w._debug_tenants = set(['98dd9c41-d3ac-4fd6-8927-567afa0b8fc3'])
 
-        tenant_id = '1234'
-        router_id = '5678'
+        tenant_id = '98dd9c41-d3ac-4fd6-8927-567afa0b8fc3'
+        router_id = 'ac194fc5-f317-412e-8611-fb290629f624'
         msg = event.Event(
             tenant_id=tenant_id,
             router_id=router_id,
@@ -438,3 +440,22 @@ class TestConfigReload(unittest.TestCase):
         self.w.handle_message(tenant_id, msg)
         self.assertTrue(self.conf.called)
         self.assertTrue(self.conf.log_opt_values.called)
+
+
+class TestNormalizeUUID(unittest.TestCase):
+
+    def test_upper(self):
+        self.assertEqual(
+            'ac194fc5-f317-412e-8611-fb290629f624',
+            worker._normalize_uuid(
+                'ac194fc5-f317-412e-8611-fb290629f624'.upper()
+            )
+        )
+
+    def test_no_dashes(self):
+        self.assertEqual(
+            'ac194fc5-f317-412e-8611-fb290629f624',
+            worker._normalize_uuid(
+                'ac194fc5f317412e8611fb290629f624'
+            )
+        )

--- a/akanda/rug/worker.py
+++ b/akanda/rug/worker.py
@@ -6,6 +6,7 @@ import logging
 import os
 import Queue
 import threading
+import uuid
 
 from oslo.config import cfg
 
@@ -16,6 +17,10 @@ from akanda.rug.api import nova
 from akanda.rug.api import quantum
 
 LOG = logging.getLogger(__name__)
+
+
+def _normalize_uuid(value):
+    return str(uuid.UUID(value.replace('-', '')))
 
 
 class WorkerContext(object):
@@ -170,13 +175,15 @@ class Worker(object):
     def _get_trms(self, target):
         if target == '*':
             return list(self.tenant_managers.values())
-        if target not in self.tenant_managers:
-            LOG.debug('creating tenant manager for %s', target)
-            self.tenant_managers[target] = tenant.TenantRouterManager(
-                tenant_id=target,
+        # Normalize the tenant id to a dash-separated UUID format.
+        tenant_id = _normalize_uuid(target)
+        if tenant_id not in self.tenant_managers:
+            LOG.debug('creating tenant manager for %s', tenant_id)
+            self.tenant_managers[tenant_id] = tenant.TenantRouterManager(
+                tenant_id=tenant_id,
                 notify_callback=self.notifier.publish,
             )
-        return [self.tenant_managers[target]]
+        return [self.tenant_managers[tenant_id]]
 
     def handle_message(self, target, message):
         """Callback to be used in main
@@ -193,6 +200,11 @@ class Worker(object):
             # to the state machine.
             with self.lock:
                 self._deliver_message(target, message)
+
+    _EVENT_COMMANDS = {
+        commands.ROUTER_UPDATE: event.UPDATE,
+        commands.ROUTER_REBUILD: event.REBUILD,
+    }
 
     def _dispatch_command(self, target, message):
         instructions = message.body['payload']
@@ -213,17 +225,19 @@ class Worker(object):
             except KeyError:
                 pass
 
-        elif instructions['command'] == commands.ROUTER_UPDATE:
+        elif instructions['command'] in self._EVENT_COMMANDS:
             new_msg = event.Event(
                 tenant_id=message.tenant_id,
                 router_id=message.router_id,
-                crud=event.UPDATE,
+                crud=self._EVENT_COMMANDS[instructions['command']],
                 body=instructions,
             )
             # Use handle_message() to ensure we acquire the lock
-            LOG.info('sending update instruction to %s', message.tenant_id)
+            LOG.info('sending %s instruction to %s',
+                     instructions['command'], message.tenant_id)
             self.handle_message(new_msg.tenant_id, new_msg)
-            LOG.info('forced update for %s complete', message.tenant_id)
+            LOG.info('forced %s for %s complete',
+                     instructions['command'], message.tenant_id)
 
         elif instructions['command'] == commands.TENANT_DEBUG:
             tenant_id = instructions['tenant_id']

--- a/doc/source/state_machine.dot
+++ b/doc/source/state_machine.dot
@@ -17,6 +17,7 @@ digraph rug {
   CALC_ACTION -> ALIVE [ label = "ACT>[CRUP],vm:[UC]" ];
   CALC_ACTION -> CREATE_VM [ label = "ACT>[CRUP],vm:D" ];
   CALC_ACTION -> CHECK_BOOT [ label = "ACT>[CRUP],vm:B" ];
+  CALC_ACTION -> REBUILD_VM [ label = "ACT:E" ];
   CALC_ACTION -> STOP_VM [ label = "ACT>D or vm:G" ];
 
   ALIVE -> CREATE_VM [ label = "vm>D" ];
@@ -38,7 +39,10 @@ digraph rug {
 
   STATS -> CALC_ACTION [ label = "ACT>P" ];
 
-  STOP_VM -> CREATE_VM [ label = "vm>D" ];
+  REBUILD_VM -> REBUILD_VM [ label = "vm!=[DG]" ];
+  REBUILD_VM -> CREATE_VM [ label = "ACT:E,vm:D" ];
+
+  STOP_VM -> CREATE_VM [ label = "ACT:E or vm>D" ];
   STOP_VM -> EXIT [ label = "ACT:D,vm>D or vm:G" ];
 
 }

--- a/doc/source/state_machine.rst
+++ b/doc/source/state_machine.rst
@@ -24,6 +24,7 @@ ACT(ion) Variable
 :Update: Update router configuration.
 :Delete: Delete router.
 :Poll: Poll router alive status.
+:rEbuild: Recreate a router from scratch.
 
 vm Variable
 ===========

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ akanda.rug.cli =
     router debug=akanda.rug.cli.router:RouterDebug
     router manage=akanda.rug.cli.router:RouterManage
     router update=akanda.rug.cli.router:RouterUpdate
+    router rebuild=akanda.rug.cli.router:RouterRebuild
     tenant debug=akanda.rug.cli.tenant:TenantDebug
     tenant manage=akanda.rug.cli.tenant:TenantManage
     workers debug=akanda.rug.cli.worker:WorkerDebug


### PR DESCRIPTION
Add a command to forcibly rebuild a router. It works by destroying the
instance and building a new one, which is brute-force, but easy to
understand.

I also changed the worker's lookup for tenant router managers so the tenant
id is normalized cleanly to avoid confusion since some events use '-' and
some do not (yay, consistent!).

Change-Id: I79a622b0c6cc23041da55ec2f54f79ccf463379e
