### PR TITLE
Send the router its default gateway IP

### DIFF
--- a/akanda/rug/api/configuration.py
+++ b/akanda/rug/api/configuration.py
@@ -47,12 +47,12 @@ def build_config(client, router, interfaces):
     provider_rules = load_provider_rules(cfg.CONF.provider_rules_path)
 
     networks = generate_network_config(client, router, interfaces)
-    gateway = get_default_gateway(client, router, interfaces, networks)
+    gateway = get_default_v4_gateway(client, router, interfaces, networks)
 
     return {
         'asn': cfg.CONF.asn,
         'neighbor_asn': cfg.CONF.neighbor_asn,
-        'default_gateway': gateway,
+        'default_v4_gateway': gateway,
         'networks': networks,
         'address_book': generate_address_book_config(client, router),
         'anchors': generate_anchor_config(client, provider_rules, router),
@@ -62,7 +62,7 @@ def build_config(client, router, interfaces):
     }
 
 
-def get_default_gateway(client, router, interfaces, networks):
+def get_default_v4_gateway(client, router, interfaces, networks):
     """Find the IPv4 default gateway for the router.
     """
     # LOG.debug('interfaces = %r', interfaces)

--- a/akanda/rug/api/configuration.py
+++ b/akanda/rug/api/configuration.py
@@ -18,6 +18,7 @@
 import logging
 import re
 
+import netaddr
 from oslo.config import cfg
 
 from akanda.rug.openstack.common import jsonutils
@@ -45,16 +46,71 @@ SERVICE_RA = 'ra'
 def build_config(client, router, interfaces):
     provider_rules = load_provider_rules(cfg.CONF.provider_rules_path)
 
+    networks = generate_network_config(client, router, interfaces)
+    gateway = get_default_gateway(client, router, interfaces, networks)
+
     return {
         'asn': cfg.CONF.asn,
         'neighbor_asn': cfg.CONF.neighbor_asn,
-        'networks': generate_network_config(client, router, interfaces),
+        'default_gateway': gateway,
+        'networks': networks,
         'address_book': generate_address_book_config(client, router),
         'anchors': generate_anchor_config(client, provider_rules, router),
         'labels': provider_rules.get('labels', {}),
         'floating_ips': generate_floating_config(router),
-        'tenant_id': router.tenant_id
+        'tenant_id': router.tenant_id,
     }
+
+
+def get_default_gateway(client, router, interfaces, networks):
+    """Find the IPv4 default gateway for the router.
+    """
+    # LOG.debug('interfaces = %r', interfaces)
+    # LOG.debug('networks = %r', networks)
+
+    # Build a list of the v4 addresses on the external
+    # interface.
+    v4_addresses = []
+    for iface in interfaces:
+        if iface['lladdr'] != router.external_port.mac_address:
+            # Ignore internal interfaces.
+            continue
+        LOG.debug('%s: Looking at addresses on %r', router.id, iface)
+        for ip in iface['addresses']:
+            # The addresses look like CIDR values, but we don't want
+            # networks we want IPs. Strip the subnet length value.
+            addr = netaddr.IPAddress(ip.partition('/')[0])
+            if addr.version == 4:
+                v4_addresses.append(addr)
+
+    # Now find the subnet that our external IP is on, and return its
+    # gateway.
+    for n in networks:
+        if n['network_type'] == EXTERNAL_NET:
+            for s in n['subnets']:
+                subnet = netaddr.IPNetwork(s['cidr'])
+                if subnet.version != 4:
+                    continue
+                LOG.debug(
+                    '%s: checking if subnet %s should have the default route',
+                    router.id, s['cidr'])
+                for addr in v4_addresses:
+                    if addr in subnet:
+                        LOG.debug(
+                            '%s: found gateway %s for subnet %s on network %s',
+                            router.id,
+                            s['gateway_ip'],
+                            s['cidr'],
+                            n['network_id'],
+                        )
+                        return s['gateway_ip']
+
+    # Sometimes we are asked to build a configuration for the server
+    # when the external interface is still marked as "down". We can
+    # report that case, but we don't treat it as an error here because
+    # we'll be asked to do it again when the interface comes up.
+    LOG.info('%s: no default gateway was found', router.id)
+    return ''
 
 
 def load_provider_rules(path):

--- a/akanda/rug/api/configuration.py
+++ b/akanda/rug/api/configuration.py
@@ -65,8 +65,9 @@ def build_config(client, router, interfaces):
 def get_default_v4_gateway(client, router, interfaces, networks):
     """Find the IPv4 default gateway for the router.
     """
-    # LOG.debug('interfaces = %r', interfaces)
-    # LOG.debug('networks = %r', networks)
+    LOG.debug('interfaces = %r', interfaces)
+    LOG.debug('networks = %r', networks)
+    LOG.debug('external interface = %s', router.external_port.mac_address)
 
     # Build a list of the v4 addresses on the external
     # interface.
@@ -74,6 +75,7 @@ def get_default_v4_gateway(client, router, interfaces, networks):
     for iface in interfaces:
         if iface['lladdr'] != router.external_port.mac_address:
             # Ignore internal interfaces.
+            LOG.debug('ignoring interface %s', iface['lladdr'])
             continue
         LOG.debug('%s: Looking at addresses on %r', router.id, iface)
         for ip in iface['addresses']:

--- a/akanda/rug/test/unit/api/test_configuration.py
+++ b/akanda/rug/test/unit/api/test_configuration.py
@@ -547,7 +547,7 @@ class TestAkandaClientGateway(unittest.TestCase):
                                                  self.interfaces, self.networks)
         self.assertEqual(result, '172.16.77.1')
 
-    def test_without_ipv4_on_external_net(self):
+    def test_without_ipv4_on_external_port(self):
         # Sometimes we get network info for the router before the IPv4
         # address is properly assigned to a port.
         self.interfaces[0]['addresses'] = [
@@ -558,3 +558,15 @@ class TestAkandaClientGateway(unittest.TestCase):
         result = conf_mod.get_default_v4_gateway(mock_client, fake_router,
                                                  self.interfaces, self.networks)
         self.assertEqual(result, '')
+
+    def test_extra_ipv4_on_external_port(self):
+        self.interfaces[0]['addresses'] = [
+            u'fe80::f816:3eff:fe4d:bf12/64',
+            u'fdca:3ba5:a17a:acda:f816:3eff:fe4d:bf12/64',
+            u'172.16.77.2',
+            u'192.168.1.1',
+        ]
+        mock_client = mock.Mock()
+        result = conf_mod.get_default_v4_gateway(mock_client, fake_router,
+                                                 self.interfaces, self.networks)
+        self.assertEqual(result, '172.16.77.1')

--- a/akanda/rug/test/unit/api/test_configuration.py
+++ b/akanda/rug/test/unit/api/test_configuration.py
@@ -126,7 +126,7 @@ class TestAkandaClient(unittest.TestCase):
             config = conf_mod.build_config(mock_client, fake_router, ifaces)
 
             expected = {
-                'default_gateway': '',
+                'default_v4_gateway': '',
                 'networks': network_config,
                 'address_book': 'ab_config',
                 'anchors': 'anchor_config',

--- a/akanda/rug/test/unit/api/test_configuration.py
+++ b/akanda/rug/test/unit/api/test_configuration.py
@@ -87,7 +87,8 @@ class TestAkandaClient(unittest.TestCase):
             'generate_network_config': mock.DEFAULT,
             'generate_address_book_config': mock.DEFAULT,
             'generate_anchor_config': mock.DEFAULT,
-            'generate_floating_config': mock.DEFAULT
+            'generate_floating_config': mock.DEFAULT,
+            'get_default_v4_gateway': mock.DEFAULT,
         }
 
         mock_client = mock.Mock()
@@ -122,11 +123,12 @@ class TestAkandaClient(unittest.TestCase):
             mocks['generate_address_book_config'].return_value = 'ab_config'
             mocks['generate_anchor_config'].return_value = 'anchor_config'
             mocks['generate_floating_config'].return_value = 'floating_config'
+            mocks['get_default_v4_gateway'].return_value = 'default_gw'
 
             config = conf_mod.build_config(mock_client, fake_router, ifaces)
 
             expected = {
-                'default_v4_gateway': '',
+                'default_v4_gateway': 'default_gw',
                 'networks': network_config,
                 'address_book': 'ab_config',
                 'anchors': 'anchor_config',
@@ -433,3 +435,126 @@ class TestAkandaClient(unittest.TestCase):
         expected = [{'floating_ip': '9.9.9.9', 'fixed_ip': '192.168.1.1'}]
 
         self.assertEqual(result, expected)
+
+
+class TestAkandaClientGateway(unittest.TestCase):
+
+    def setUp(self):
+        cfg.CONF.set_override('provider_rules_path', '/the/path')
+        # Sample data taken from a real devstack-created system, with
+        # the external MAC address modified to match the fake port in
+        # use for the mocked router.
+        self.interfaces = [
+            {u'addresses': [u'fe80::f816:3eff:fe4d:bf12/64',
+                            u'fdca:3ba5:a17a:acda:f816:3eff:fe4d:bf12/64',
+                            u'172.16.77.2'],
+             u'media': u'Ethernet autoselect',
+             u'lladdr': fake_ext_port.mac_address,
+             u'state': u'up',
+             u'groups': [],
+             u'ifname': u'ge0',
+             u'mtu': 1500,
+             u'description': u''},
+            {u'addresses': [u'10.0.0.2'],
+             u'media': u'Ethernet autoselect',
+             u'lladdr': u'fa:16:3e:e5:17:42',
+             u'state': u'down',
+             u'groups': [],
+             u'ifname': u'ge1',
+             u'mtu': 1500,
+             u'description': u''},
+            {u'addresses': [],
+             u'media': u'Ethernet autoselect',
+             u'lladdr': u'fa:16:3e:1b:93:76',
+             u'state': u'down',
+             u'groups': [],
+             u'ifname': u'ge2',
+             u'mtu': 1500,
+             u'description': u''}]
+        self.networks = [
+            {'subnets': [
+                {'host_routes': [],
+                 'cidr': '172.16.77.0/24',
+                 'gateway_ip': '172.16.77.1',
+                 'dns_nameservers': [],
+                 'dhcp_enabled': True,
+                 'network_type': 'external',},
+                {'host_routes': [],
+                 'cidr': 'fdee:9f85:83be::/48',
+                 'gateway_ip': 'fdee:9f85:83be::1',
+                 'dns_nameservers': [],
+                 'dhcp_enabled': True}],
+             'v6_conf_service': 'static',
+             'network_id': u'1e109e80-4a6a-483e-9dd4-2ff31adf25f5',
+             'allocations': [],
+             'interface': {'ifname': u'ge1',
+                           'addresses': ['172.16.77.2/24',
+                                         'fdee:9f85:83be:0:f816:3eff:fee5:1742/48']},
+             'v4_conf_service': 'static',
+             'network_type': 'external'},
+            {'subnets': [],
+             'v6_conf_service': 'static',
+             'network_id': u'698ef1d1-1089-48ab-80b0-f994a962891c',
+             'allocations': [],
+             'interface': {u'addresses': [u'fe80::f816:3eff:fe4d:bf12/64',
+                                          u'fdca:3ba5:a17a:acda:f816:3eff:fe4d:bf12/64'],
+                           u'media': u'Ethernet autoselect',
+                           u'lladdr': u'fa:16:3e:4d:bf:12',
+                           u'state': u'up',
+                           u'groups': [],
+                           u'ifname': u'ge0',
+                           u'mtu': 1500,
+                           u'description': u''},
+             'v4_conf_service': 'static',
+             'network_type': 'management'},
+            {'subnets': [
+                {'host_routes': [],
+                 'cidr': 'fdd6:a1fa:cfa8:6c94::/64',
+                 'gateway_ip': 'fdd6:a1fa:cfa8:6c94::1',
+                 'dns_nameservers': [],
+                 'dhcp_enabled': False},
+                {'host_routes': [],
+                 'cidr': '192.168.0.0/24',
+                 'gateway_ip': '192.168.0.1',
+                 'dns_nameservers': [],
+                 'dhcp_enabled': True}],
+             'v6_conf_service': 'static',
+             'network_id': u'a1ea2256-5e57-4e9e-8b7a-8bf17eb76b73',
+             'allocations': [
+                 {'mac_address': u'fa:16:3e:1b:93:76',
+                  'ip_addresses': {'fdd6:a1fa:cfa8:6c94::1': False,
+                                   '192.168.0.1': True},
+                  'hostname': '192-168-0-1.local',
+                  'device_id': u'c72a34fb-fb56-4ee7-b9b2-6467eb1c45d6'}],
+             'interface': {'ifname': u'ge2',
+                           'addresses': ['192.168.0.1/24',
+                                         'fdd6:a1fa:cfa8:6c94::1/64']},
+             'v4_conf_service': 'static',
+             'network_type': 'internal'}]
+
+    def tearDown(self):
+        cfg.CONF.reset()
+
+    def test_no_interfaces(self):
+        mock_client = mock.Mock()
+        result = conf_mod.get_default_v4_gateway(mock_client, fake_router,
+                                                 [], self.networks)
+        self.assertEqual(result, '')
+
+    def test_with_interfaces(self):
+        mock_client = mock.Mock()
+        result = conf_mod.get_default_v4_gateway(mock_client, fake_router,
+                                                 self.interfaces, self.networks)
+        self.assertEqual(result, '172.16.77.1')
+
+    def test_without_ipv4_on_external_net(self):
+        # Sometimes we get network info for the router before the IPv4
+        # address is properly assigned to a port.
+        self.interfaces[0]['addresses'] = [
+            u'fe80::f816:3eff:fe4d:bf12/64',
+            u'fdca:3ba5:a17a:acda:f816:3eff:fe4d:bf12/64',
+        ]
+        mock_client = mock.Mock()
+        result = conf_mod.get_default_v4_gateway(mock_client, fake_router,
+                                                 self.interfaces, self.networks)
+        self.assertEqual(result, '')

--- a/akanda/rug/test/unit/api/test_configuration.py
+++ b/akanda/rug/test/unit/api/test_configuration.py
@@ -478,7 +478,7 @@ class TestAkandaClientGateway(unittest.TestCase):
                  'gateway_ip': '172.16.77.1',
                  'dns_nameservers': [],
                  'dhcp_enabled': True,
-                 'network_type': 'external',},
+                 'network_type': 'external'},
                 {'host_routes': [],
                  'cidr': 'fdee:9f85:83be::/48',
                  'gateway_ip': 'fdee:9f85:83be::1',
@@ -488,23 +488,28 @@ class TestAkandaClientGateway(unittest.TestCase):
              'network_id': u'1e109e80-4a6a-483e-9dd4-2ff31adf25f5',
              'allocations': [],
              'interface': {'ifname': u'ge1',
-                           'addresses': ['172.16.77.2/24',
-                                         'fdee:9f85:83be:0:f816:3eff:fee5:1742/48']},
+                           'addresses': [
+                               '172.16.77.2/24',
+                               'fdee:9f85:83be:0:f816:3eff:fee5:1742/48',
+                           ]},
              'v4_conf_service': 'static',
              'network_type': 'external'},
             {'subnets': [],
              'v6_conf_service': 'static',
              'network_id': u'698ef1d1-1089-48ab-80b0-f994a962891c',
              'allocations': [],
-             'interface': {u'addresses': [u'fe80::f816:3eff:fe4d:bf12/64',
-                                          u'fdca:3ba5:a17a:acda:f816:3eff:fe4d:bf12/64'],
-                           u'media': u'Ethernet autoselect',
-                           u'lladdr': u'fa:16:3e:4d:bf:12',
-                           u'state': u'up',
-                           u'groups': [],
-                           u'ifname': u'ge0',
-                           u'mtu': 1500,
-                           u'description': u''},
+             'interface': {
+                 u'addresses': [
+                     u'fe80::f816:3eff:fe4d:bf12/64',
+                     u'fdca:3ba5:a17a:acda:f816:3eff:fe4d:bf12/64',
+                 ],
+                 u'media': u'Ethernet autoselect',
+                 u'lladdr': u'fa:16:3e:4d:bf:12',
+                 u'state': u'up',
+                 u'groups': [],
+                 u'ifname': u'ge0',
+                 u'mtu': 1500,
+                 u'description': u''},
              'v4_conf_service': 'static',
              'network_type': 'management'},
             {'subnets': [
@@ -522,8 +527,9 @@ class TestAkandaClientGateway(unittest.TestCase):
              'network_id': u'a1ea2256-5e57-4e9e-8b7a-8bf17eb76b73',
              'allocations': [
                  {'mac_address': u'fa:16:3e:1b:93:76',
-                  'ip_addresses': {'fdd6:a1fa:cfa8:6c94::1': False,
-                                   '192.168.0.1': True},
+                  'ip_addresses': {
+                      'fdd6:a1fa:cfa8:6c94::1': False,
+                      '192.168.0.1': True},
                   'hostname': '192-168-0-1.local',
                   'device_id': u'c72a34fb-fb56-4ee7-b9b2-6467eb1c45d6'}],
              'interface': {'ifname': u'ge2',
@@ -543,8 +549,10 @@ class TestAkandaClientGateway(unittest.TestCase):
 
     def test_with_interfaces(self):
         mock_client = mock.Mock()
-        result = conf_mod.get_default_v4_gateway(mock_client, fake_router,
-                                                 self.interfaces, self.networks)
+        result = conf_mod.get_default_v4_gateway(
+            mock_client, fake_router,
+            self.interfaces, self.networks,
+        )
         self.assertEqual(result, '172.16.77.1')
 
     def test_without_ipv4_on_external_port(self):
@@ -555,8 +563,10 @@ class TestAkandaClientGateway(unittest.TestCase):
             u'fdca:3ba5:a17a:acda:f816:3eff:fe4d:bf12/64',
         ]
         mock_client = mock.Mock()
-        result = conf_mod.get_default_v4_gateway(mock_client, fake_router,
-                                                 self.interfaces, self.networks)
+        result = conf_mod.get_default_v4_gateway(
+            mock_client, fake_router,
+            self.interfaces, self.networks,
+        )
         self.assertEqual(result, '')
 
     def test_extra_ipv4_on_external_port(self):
@@ -567,6 +577,8 @@ class TestAkandaClientGateway(unittest.TestCase):
             u'192.168.1.1',
         ]
         mock_client = mock.Mock()
-        result = conf_mod.get_default_v4_gateway(mock_client, fake_router,
-                                                 self.interfaces, self.networks)
+        result = conf_mod.get_default_v4_gateway(
+            mock_client, fake_router,
+            self.interfaces, self.networks,
+        )
         self.assertEqual(result, '172.16.77.1')

--- a/akanda/rug/test/unit/api/test_configuration.py
+++ b/akanda/rug/test/unit/api/test_configuration.py
@@ -93,10 +93,32 @@ class TestAkandaClient(unittest.TestCase):
         mock_client = mock.Mock()
         ifaces = []
         provider_rules = {'labels': {'ext': ['192.168.1.1']}}
+        network_config = [
+            {'interface': 1,
+             'network_id': 2,
+             'v4_conf_service': 'static',
+             'v6_conf_service': 'static',
+             'network_type': 'external',
+             'subnets': [
+                 {'cidr': '192.168.1.0/24',
+                  'dhcp_enabled': True,
+                  'dns_nameservers': [],
+                  'host_routes': [],
+                  'gateway_ip': '192.168.1.1',
+                  },
+                 {'cidr': '10.0.0.0/24',
+                  'dhcp_enabled': True,
+                  'dns_nameservers': [],
+                  'host_routes': [],
+                  'gateway_ip': '10.0.0.1',
+                  },
+                 ],
+             'allocations': []}
+        ]
 
         with mock.patch.multiple(conf_mod, **methods) as mocks:
             mocks['load_provider_rules'].return_value = provider_rules
-            mocks['generate_network_config'].return_value = 'network_config'
+            mocks['generate_network_config'].return_value = network_config
             mocks['generate_address_book_config'].return_value = 'ab_config'
             mocks['generate_anchor_config'].return_value = 'anchor_config'
             mocks['generate_floating_config'].return_value = 'floating_config'
@@ -104,7 +126,8 @@ class TestAkandaClient(unittest.TestCase):
             config = conf_mod.build_config(mock_client, fake_router, ifaces)
 
             expected = {
-                'networks': 'network_config',
+                'default_gateway': '',
+                'networks': network_config,
                 'address_book': 'ab_config',
                 'anchors': 'anchor_config',
                 'labels': {'ext': ['192.168.1.1']},


### PR DESCRIPTION
Each router may have multiple public IPs, but we only want it to use a single
default gateway. We work out what that value should be in the rug, and send
it to the appliance so the appliance does not have to figure it out for
itself.

Change-Id: Ie8ae8a866ee46ed9b0b3d5ef79c2a4fadf1b7f0a
