### PR TITLE
Harden UUID parsing

### DIFF
--- a/akanda/rug/scheduler.py
+++ b/akanda/rug/scheduler.py
@@ -67,12 +67,18 @@ class Dispatcher(object):
     def pick_workers(self, target):
         """Returns the workers that match the target.
         """
+        target = target.strip()
         # If we get the wildcard target, send the message to all of
         # the workers.
         if target in ['*', 'debug']:
             return self.workers[:]
-        idx = uuid.UUID(target).int % len(self.workers)
-        LOG.debug('target %s maps to worker %s', target, idx)
+        try:
+            idx = uuid.UUID(target).int % len(self.workers)
+        except ValueError:
+            LOG.warning('could not determine UUID from %r, ignoring message', target)
+            return []
+        else:
+            LOG.debug('target %s maps to worker %s', target, idx)
         return [self.workers[idx]]
 
 

--- a/akanda/rug/scheduler.py
+++ b/akanda/rug/scheduler.py
@@ -67,15 +67,18 @@ class Dispatcher(object):
     def pick_workers(self, target):
         """Returns the workers that match the target.
         """
-        target = target.strip()
+        target = target.strip() if target else None
         # If we get the wildcard target, send the message to all of
         # the workers.
         if target in ['*', 'debug']:
             return self.workers[:]
         try:
             idx = uuid.UUID(target).int % len(self.workers)
-        except ValueError:
-            LOG.warning('could not determine UUID from %r, ignoring message', target)
+        except (TypeError, ValueError) as e:
+            LOG.warning(
+                'could not determine UUID from %r: %s, ignoring message',
+                target, e,
+            )
             return []
         else:
             LOG.debug('target %s maps to worker %s', target, idx)

--- a/akanda/rug/test/unit/test_scheduler.py
+++ b/akanda/rug/test/unit/test_scheduler.py
@@ -69,6 +69,14 @@ class TestDispatcher(unittest.TestCase):
                 'Incorrect index for %s' % router_id,
             )
 
+    def test_pick_none(self):
+        router_id = None
+        self.assertEqual(
+            [],
+            self.d.pick_workers(router_id),
+            'Found a router for None',
+        )
+
     def test_pick_with_spaces(self):
         for i in range(len(self.workers)):
             router_id = ' %s ' % self._mk_uuid(i)

--- a/akanda/rug/test/unit/test_scheduler.py
+++ b/akanda/rug/test/unit/test_scheduler.py
@@ -69,6 +69,24 @@ class TestDispatcher(unittest.TestCase):
                 'Incorrect index for %s' % router_id,
             )
 
+    def test_pick_with_spaces(self):
+        for i in range(len(self.workers)):
+            router_id = ' %s ' % self._mk_uuid(i)
+            self.assertEqual(
+                [i],
+                self.d.pick_workers(router_id),
+                'Incorrect index for %s' % router_id,
+            )
+
+    def test_pick_invalid(self):
+        for i in range(len(self.workers)):
+            router_id = self._mk_uuid(i) + 'Z'
+            self.assertEqual(
+                [],
+                self.d.pick_workers(router_id),
+                'Found unexpected worker for %r' % router_id,
+            )
+
     def test_wildcard(self):
         self.assertEqual(
             self.workers,


### PR DESCRIPTION
If the scheduler sees a UUID that is not formatted properly, it should ignore
the message as invalid.

Change-Id: I4aff1cd035bc80902dfc37f693f33aad6cdc146d
