### PR TITLE
Log but otherwise ignore errors in main loop

### DIFF
--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -55,6 +55,8 @@ def shuffle_notifications(notification_queue, sched):
         except KeyboardInterrupt:
             LOG.info('got Ctrl-C')
             break
+        except:
+            LOG.exception('unhandled exception processing message')
 
 
 def register_and_load_opts():

--- a/akanda/rug/test/unit/test_main.py
+++ b/akanda/rug/test/unit/test_main.py
@@ -44,6 +44,21 @@ class TestMainPippo(unittest.TestCase):
         sched.handle_message.assert_called_once('message')
         sched.stop.assert_called_once()
 
+    def test_shuffle_notifications_error(
+            self, shuffle_notifications,
+            health, populate, scheduler, notifications,
+            multiprocessing, quantum_api, cfg):
+        queue = mock.Mock()
+        queue.get.side_effect = [
+            ('9306bbd8-f3cc-11e2-bd68-080027e60b25', 'message'),
+            RuntimeError,
+            KeyboardInterrupt,
+        ]
+        sched = scheduler.Scheduler.return_value
+        main.shuffle_notifications(queue, sched)
+        sched.handle_message.assert_called_once('message')
+        sched.stop.assert_called_once()
+
     def test_ensure_local_service_port(self, shuffle_notifications, health,
                                        populate, scheduler, notifications,
                                        multiprocessing, quantum_api, cfg):


### PR DESCRIPTION
Don't let the main loop break out on an unhandled exception. Log it, and keep
trying.

Change-Id: Ie382a00fb4b657ffe8875ab4089b31dde241dc28
