### PR TITLE
Look at subnets, not interfaces, for gateway

### DIFF
--- a/akanda/rug/api/configuration.py
+++ b/akanda/rug/api/configuration.py
@@ -68,22 +68,6 @@ def get_default_v4_gateway(client, router, networks):
     LOG.debug('networks = %r', networks)
     LOG.debug('external interface = %s', router.external_port.mac_address)
 
-    # Build a list of the v4 addresses on the external
-    # interface.
-    # v4_addresses = []
-    # for iface in interfaces:
-    #     if iface['lladdr'] != router.external_port.mac_address:
-    #         # Ignore internal interfaces.
-    #         LOG.debug('ignoring interface %s', iface['lladdr'])
-    #         continue
-    #     LOG.debug('%s: Looking at addresses on %r', router.id, iface)
-    #     for ip in iface['addresses']:
-    #         # The addresses look like CIDR values, but we don't want
-    #         # networks we want IPs. Strip the subnet length value.
-    #         addr = netaddr.IPAddress(ip.partition('/')[0])
-    #         if addr.version == 4:
-    #             v4_addresses.append(addr)
-
     # Now find the subnet that our external IP is on, and return its
     # gateway.
     for n in networks:

--- a/akanda/rug/api/configuration.py
+++ b/akanda/rug/api/configuration.py
@@ -47,7 +47,7 @@ def build_config(client, router, interfaces):
     provider_rules = load_provider_rules(cfg.CONF.provider_rules_path)
 
     networks = generate_network_config(client, router, interfaces)
-    gateway = get_default_v4_gateway(client, router, interfaces, networks)
+    gateway = get_default_v4_gateway(client, router, networks)
 
     return {
         'asn': cfg.CONF.asn,
@@ -62,33 +62,38 @@ def build_config(client, router, interfaces):
     }
 
 
-def get_default_v4_gateway(client, router, interfaces, networks):
+def get_default_v4_gateway(client, router, networks):
     """Find the IPv4 default gateway for the router.
     """
-    LOG.debug('interfaces = %r', interfaces)
     LOG.debug('networks = %r', networks)
     LOG.debug('external interface = %s', router.external_port.mac_address)
 
     # Build a list of the v4 addresses on the external
     # interface.
-    v4_addresses = []
-    for iface in interfaces:
-        if iface['lladdr'] != router.external_port.mac_address:
-            # Ignore internal interfaces.
-            LOG.debug('ignoring interface %s', iface['lladdr'])
-            continue
-        LOG.debug('%s: Looking at addresses on %r', router.id, iface)
-        for ip in iface['addresses']:
-            # The addresses look like CIDR values, but we don't want
-            # networks we want IPs. Strip the subnet length value.
-            addr = netaddr.IPAddress(ip.partition('/')[0])
-            if addr.version == 4:
-                v4_addresses.append(addr)
+    # v4_addresses = []
+    # for iface in interfaces:
+    #     if iface['lladdr'] != router.external_port.mac_address:
+    #         # Ignore internal interfaces.
+    #         LOG.debug('ignoring interface %s', iface['lladdr'])
+    #         continue
+    #     LOG.debug('%s: Looking at addresses on %r', router.id, iface)
+    #     for ip in iface['addresses']:
+    #         # The addresses look like CIDR values, but we don't want
+    #         # networks we want IPs. Strip the subnet length value.
+    #         addr = netaddr.IPAddress(ip.partition('/')[0])
+    #         if addr.version == 4:
+    #             v4_addresses.append(addr)
 
     # Now find the subnet that our external IP is on, and return its
     # gateway.
     for n in networks:
         if n['network_type'] == EXTERNAL_NET:
+            v4_addresses = [
+                addr
+                for addr in (netaddr.IPAddress(ip.partition('/')[0])
+                             for ip in n['interface']['addresses'])
+                if addr.version == 4
+            ]
             for s in n['subnets']:
                 subnet = netaddr.IPNetwork(s['cidr'])
                 if subnet.version != 4:

--- a/akanda/rug/test/unit/api/test_configuration.py
+++ b/akanda/rug/test/unit/api/test_configuration.py
@@ -444,33 +444,6 @@ class TestAkandaClientGateway(unittest.TestCase):
         # Sample data taken from a real devstack-created system, with
         # the external MAC address modified to match the fake port in
         # use for the mocked router.
-        self.interfaces = [
-            {u'addresses': [u'fe80::f816:3eff:fe4d:bf12/64',
-                            u'fdca:3ba5:a17a:acda:f816:3eff:fe4d:bf12/64',
-                            u'172.16.77.2'],
-             u'media': u'Ethernet autoselect',
-             u'lladdr': fake_ext_port.mac_address,
-             u'state': u'up',
-             u'groups': [],
-             u'ifname': u'ge0',
-             u'mtu': 1500,
-             u'description': u''},
-            {u'addresses': [u'10.0.0.2'],
-             u'media': u'Ethernet autoselect',
-             u'lladdr': u'fa:16:3e:e5:17:42',
-             u'state': u'down',
-             u'groups': [],
-             u'ifname': u'ge1',
-             u'mtu': 1500,
-             u'description': u''},
-            {u'addresses': [],
-             u'media': u'Ethernet autoselect',
-             u'lladdr': u'fa:16:3e:1b:93:76',
-             u'state': u'down',
-             u'groups': [],
-             u'ifname': u'ge2',
-             u'mtu': 1500,
-             u'description': u''}]
         self.networks = [
             {'subnets': [
                 {'host_routes': [],
@@ -541,44 +514,39 @@ class TestAkandaClientGateway(unittest.TestCase):
     def tearDown(self):
         cfg.CONF.reset()
 
-    def test_no_interfaces(self):
-        mock_client = mock.Mock()
-        result = conf_mod.get_default_v4_gateway(mock_client, fake_router,
-                                                 [], self.networks)
-        self.assertEqual(result, '')
-
     def test_with_interfaces(self):
         mock_client = mock.Mock()
         result = conf_mod.get_default_v4_gateway(
-            mock_client, fake_router,
-            self.interfaces, self.networks,
+            mock_client,
+            fake_router,
+            self.networks,
         )
         self.assertEqual(result, '172.16.77.1')
 
     def test_without_ipv4_on_external_port(self):
-        # Sometimes we get network info for the router before the IPv4
-        # address is properly assigned to a port.
-        self.interfaces[0]['addresses'] = [
-            u'fe80::f816:3eff:fe4d:bf12/64',
-            u'fdca:3ba5:a17a:acda:f816:3eff:fe4d:bf12/64',
+        # Only set a V6 address
+        self.networks[0]['interface']['addresses'] = [
+            'fdee:9f85:83be:0:f816:3eff:fee5:1742/48',
         ]
         mock_client = mock.Mock()
         result = conf_mod.get_default_v4_gateway(
-            mock_client, fake_router,
-            self.interfaces, self.networks,
+            mock_client,
+            fake_router,
+            self.networks,
         )
         self.assertEqual(result, '')
 
     def test_extra_ipv4_on_external_port(self):
-        self.interfaces[0]['addresses'] = [
+        self.networks[0]['interface']['addresses'] = [
             u'fe80::f816:3eff:fe4d:bf12/64',
             u'fdca:3ba5:a17a:acda:f816:3eff:fe4d:bf12/64',
-            u'172.16.77.2',
             u'192.168.1.1',
+            u'172.16.77.2',
         ]
         mock_client = mock.Mock()
         result = conf_mod.get_default_v4_gateway(
-            mock_client, fake_router,
-            self.interfaces, self.networks,
+            mock_client,
+            fake_router,
+            self.networks,
         )
         self.assertEqual(result, '172.16.77.1')


### PR DESCRIPTION
Look at the subnet settings to determine the IPs we have on each network,
instead of looking at the interface settings which might not yet be populated
fully.

Change-Id: I2318c3037cd9a2cd959bd238835a0d605560c110
