### PR TITLE
Ignore errors updating the router status

### DIFF
--- a/akanda/rug/api/quantum.py
+++ b/akanda/rug/api/quantum.py
@@ -551,7 +551,16 @@ class Quantum(object):
             driver.unplug(device_name)
 
     def update_router_status(self, router_id, status):
-        self.api_client.update_router_status(router_id, status)
+        try:
+            self.api_client.update_router_status(router_id, status)
+        except Exception as e:
+            # We don't want to die just because we can't tell neutron
+            # what the status of the router should be. Log the error
+            # but otherwise ignore it.
+            LOG.info(
+                'ignoring failure to update status for router %s to %s: %s',
+                router_id, status, e,
+            )
 
     def clear_device_id(self, port):
         self.api_client.update_port(port.id, {'port': {'device_id': ''}})

--- a/akanda/rug/test/unit/api/test_quantum_wrapper.py
+++ b/akanda/rug/test/unit/api/test_quantum_wrapper.py
@@ -252,6 +252,14 @@ class TestQuantumWrapper(unittest.TestCase):
             'PORT1', {'port': {'device_id': ''}}
         )
 
+    @mock.patch('akanda.rug.api.quantum.AkandaExtClientWrapper')
+    def test_neutron_router_status_update_error(self, client_wrapper):
+        urs = client_wrapper.return_value.update_router_status
+        urs.side_effect = RuntimeError('should be caught')
+        conf = mock.Mock()
+        quantum_wrapper = quantum.Quantum(conf)
+        quantum_wrapper.update_router_status('router-id', 'new-status')
+
 
 class TestExternalPort(unittest.TestCase):
 


### PR DESCRIPTION
We want the router status to be correct, but we don't want a failure to 
update the status to cause other issues within the RUG. Log and discard any
exceptions that come from talking to the neutron API extension for updating
the router status.

Change-Id: I47e34a31b783e3c41f227deb48607947eb505456
