### PR TITLE
Ensure router is unlocked when resuming management

### DIFF
--- a/akanda/rug/worker.py
+++ b/akanda/rug/worker.py
@@ -247,6 +247,14 @@ class Worker(object):
                 LOG.info('Resuming management of router %s', router_id)
             except KeyError:
                 pass
+            try:
+                self._router_locks[router_id].release()
+                LOG.info('Unlocked router %s', router_id)
+            except KeyError:
+                pass
+            except threading.ThreadError:
+                # Already unlocked, that's OK.
+                pass
 
         elif instructions['command'] in self._EVENT_COMMANDS:
             new_msg = event.Event(


### PR DESCRIPTION
When a router is moved out of debug status, make sure it is unlocked so we
can put it into the work queue the next time something comes in to update it.

Change-Id: If5c5d4a8f8b8deeb840d8dd0e188fd39f8266c2f
