### PR TITLE
Protect ourselves from missing gateways on subnets

### DIFF
--- a/akanda/rug/api/configuration.py
+++ b/akanda/rug/api/configuration.py
@@ -183,7 +183,9 @@ def _subnet_config(subnet):
         'dhcp_enabled': subnet.enable_dhcp,
         'dns_nameservers': subnet.dns_nameservers,
         'host_routes': subnet.host_routes,
-        'gateway_ip': str(subnet.gateway_ip)
+        'gateway_ip': (str(subnet.gateway_ip)
+                       if subnet.gateway_ip is not None
+                       else ''),
     }
 
 

--- a/akanda/rug/test/unit/api/test_configuration.py
+++ b/akanda/rug/test/unit/api/test_configuration.py
@@ -292,8 +292,41 @@ class TestAkandaClient(unittest.TestCase):
             'gateway_ip': '192.168.1.1',
             'host_routes': {}
         }
-
         self.assertEqual(conf_mod._subnet_config(fake_subnet), expected)
+
+    def test_subnet_config_no_gateway(self):
+        expected = {
+            'cidr': '192.168.1.0/24',
+            'dhcp_enabled': True,
+            'dns_nameservers': ['8.8.8.8'],
+            'gateway_ip': '',
+            'host_routes': {}
+        }
+        sn = FakeModel(
+            's1',
+            cidr=netaddr.IPNetwork('192.168.1.0/24'),
+            gateway_ip='',
+            enable_dhcp=True,
+            dns_nameservers=['8.8.8.8'],
+            host_routes={})
+        self.assertEqual(conf_mod._subnet_config(sn), expected)
+
+    def test_subnet_config_gateway_none(self):
+        expected = {
+            'cidr': '192.168.1.0/24',
+            'dhcp_enabled': True,
+            'dns_nameservers': ['8.8.8.8'],
+            'gateway_ip': '',
+            'host_routes': {}
+        }
+        sn = FakeModel(
+            's1',
+            cidr=netaddr.IPNetwork('192.168.1.0/24'),
+            gateway_ip=None,
+            enable_dhcp=True,
+            dns_nameservers=['8.8.8.8'],
+            host_routes={})
+        self.assertEqual(conf_mod._subnet_config(sn), expected)
 
     def test_allocation_config(self):
         subnets_dict = {fake_subnet.id: fake_subnet}

--- a/akanda/rug/test/unit/api/test_quantum_wrapper.py
+++ b/akanda/rug/test/unit/api/test_quantum_wrapper.py
@@ -113,6 +113,76 @@ class TestQuantumModels(unittest.TestCase):
         self.assertEqual(s.dns_nameservers, ['8.8.8.8', '8.8.4.4'])
         self.assertEqual(s.host_routes, [])
 
+    def test_subnet_gateway_none(self):
+        d = {
+            'id': '1',
+            'tenant_id': 'tenant_id',
+            'name': 'name',
+            'network_id': 'network_id',
+            'ip_version': 6,
+            'cidr': 'fe80::/64',
+            'gateway_ip': None,
+            'enable_dhcp': True,
+            'dns_nameservers': ['8.8.8.8', '8.8.4.4'],
+            'host_routes': []
+        }
+        s = quantum.Subnet.from_dict(d)
+        self.assertEqual(s.cidr, netaddr.IPNetwork('fe80::/64'))
+        self.assertIs(None, s.gateway_ip)
+
+    def test_subnet_gateway_not_ip(self):
+        d = {
+            'id': '1',
+            'tenant_id': 'tenant_id',
+            'name': 'name',
+            'network_id': 'network_id',
+            'ip_version': 6,
+            'cidr': 'fe80::/64',
+            'gateway_ip': 'something-that-is-not-an-ip',
+            'enable_dhcp': True,
+            'dns_nameservers': ['8.8.8.8', '8.8.4.4'],
+            'host_routes': []
+        }
+        s = quantum.Subnet.from_dict(d)
+        self.assertEqual(s.cidr, netaddr.IPNetwork('fe80::/64'))
+        self.assertIs(None, s.gateway_ip)
+
+    def test_subnet_cidr_none(self):
+        d = {
+            'id': '1',
+            'tenant_id': 'tenant_id',
+            'name': 'name',
+            'network_id': 'network_id',
+            'ip_version': 6,
+            'cidr': None,
+            'gateway_ip': 'fe80::1',
+            'enable_dhcp': True,
+            'dns_nameservers': ['8.8.8.8', '8.8.4.4'],
+            'host_routes': []
+        }
+        try:
+            quantum.Subnet.from_dict(d)
+        except ValueError as e:
+            self.assertIn('Invalid CIDR', unicode(e))
+
+    def test_subnet_cidr_not_valid(self):
+        d = {
+            'id': '1',
+            'tenant_id': 'tenant_id',
+            'name': 'name',
+            'network_id': 'network_id',
+            'ip_version': 6,
+            'cidr': 'something-that-is-not-an-ip',
+            'gateway_ip': 'fe80::1',
+            'enable_dhcp': True,
+            'dns_nameservers': ['8.8.8.8', '8.8.4.4'],
+            'host_routes': []
+        }
+        try:
+            quantum.Subnet.from_dict(d)
+        except ValueError as e:
+            self.assertIn('Invalid CIDR', unicode(e))
+
     def test_port_model(self):
         d = {
             'id': '1',


### PR DESCRIPTION
Avoid throwing errors and entering an infinite update loop when the 
gateway_ip for a subnet is not set.

Change-Id: I983a24c7511d594639054320953080130047bd30
