### PR TITLE
Don't assume incoming action is valid

### DIFF
--- a/akanda/rug/state.py
+++ b/akanda/rug/state.py
@@ -84,8 +84,8 @@ class CalcAction(State):
                 queue.popleft()
                 continue
 
-            elif queue[0] == POLL:
-                # Throw away a poll following any other action,
+            elif action and queue[0] == POLL:
+                # Throw away a poll following any other valid action,
                 # because a create or update will automatically handle
                 # the poll and repeated polls are not needed.
                 self.log.debug('discarding poll event following action %s',
@@ -93,7 +93,7 @@ class CalcAction(State):
                 queue.popleft()
                 continue
 
-            elif action != POLL and action != queue[0]:
+            elif action and action != POLL and action != queue[0]:
                 # We are not polling and the next action is something
                 # different from what we are doing, so just do the
                 # current action.

--- a/akanda/rug/test/unit/test_state.py
+++ b/akanda/rug/test/unit/test_state.py
@@ -79,6 +79,18 @@ class TestCalcActionState(BaseTestStateCase):
     def test_execute_delete_in_queue(self):
         self._test_hlpr(event.DELETE, [event.CREATE, event.DELETE], 2)
 
+    def test_none_start_action_update(self):
+        self._test_hlpr(expected_action=event.UPDATE,
+                        queue_states=[event.UPDATE, event.UPDATE],
+                        leftover=0,
+                        initial_action=None)
+
+    def test_none_start_action_poll(self):
+        self._test_hlpr(expected_action=event.POLL,
+                        queue_states=[event.POLL, event.POLL],
+                        leftover=0,
+                        initial_action=None)
+
     def test_execute_ignore_pending_update_follow_create(self):
         self._test_hlpr(event.CREATE, [event.CREATE, event.UPDATE])
 


### PR DESCRIPTION
When the incoming action is None, assume the first action in the queue is the
thing we should do.

Fixes bug DHC-2153

Change-Id: I5d9e89ddd14231b141c567e9c6e190185a144409
