### PR TITLE
Log router boot durations

### DIFF
--- a/akanda/rug/test/unit/test_vmmanager.py
+++ b/akanda/rug/test/unit/test_vmmanager.py
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import datetime
 import logging
 
 import mock

--- a/akanda/rug/test/unit/test_vmmanager.py
+++ b/akanda/rug/test/unit/test_vmmanager.py
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
+import datetime
 import logging
 
 import mock
@@ -97,6 +97,7 @@ class TestVmManager(unittest.TestCase):
         # Configure the router and make sure state is synchronized as ACTIVE
         with mock.patch.object(self.vm_mgr, '_verify_interfaces') as verify:
             verify.return_value = True
+            self.vm_mgr.last_boot = datetime.utcnow()
             self.vm_mgr.configure(self.ctx)
             self.vm_mgr.update_state(self.ctx)
             n.update_router_status.assert_called_once_with('R1', 'ACTIVE')

--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -108,8 +108,9 @@ class VmManager(object):
         # After the router is all the way up, record how long it took
         # to boot and accept a configuration.
         if self.state == CONFIGURED:
-            boot_duration = (datetime.utcnow() - self.last_boot).total_seconds()
-            self.log.info('Router booted in %s seconds', boot_duration)
+            boot_duration = (datetime.utcnow() - self.last_boot)
+            self.log.info('Router booted in %s seconds',
+                          boot_duration.total_seconds())
         return self.state
 
     def boot(self, worker_context):

--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -94,7 +94,7 @@ class VmManager(object):
             if self.last_boot:
                 seconds_since_boot = (
                     datetime.utcnow() - self.last_boot
-                ).seconds
+                ).total_seconds()
                 if seconds_since_boot < cfg.CONF.boot_timeout:
                     self.state = BOOTING
                 else:
@@ -105,6 +105,11 @@ class VmManager(object):
                         'Router is DOWN.  Created over %d secs ago.',
                         cfg.CONF.boot_timeout)
 
+        # After the router is all the way up, record how long it took
+        # to boot and accept a configuration.
+        if self.state == CONFIGURED:
+            boot_duration = (datetime.utcnow() - self.last_boot).total_seconds()
+            self.log.info('Router booted in %s seconds', boot_duration)
         return self.state
 
     def boot(self, worker_context):


### PR DESCRIPTION
Log the number of seconds it takes a router to boot and accept its first
configuration.

Change-Id: Ie42beb3166e93f93bac71121e1e5e10296aaaa96
