### PR TITLE
Detect router reboot loops

### DIFF
--- a/akanda/rug/debug.py
+++ b/akanda/rug/debug.py
@@ -51,6 +51,7 @@ def debug_one_router(args=sys.argv[1:]):
                    ),
     ])
     cfg.CONF(args, project='akanda-rug')
+    cfg.CONF.set_override('boot_timeout', 60000)
 
     logging.basicConfig(
         level=logging.DEBUG,
@@ -68,12 +69,13 @@ def debug_one_router(args=sys.argv[1:]):
     context = worker.WorkerContext()
     router_obj = context.neutron.get_router_detail(cfg.CONF.router_id)
     a = state.Automaton(
-        cfg.CONF.router_id,
-        router_obj.tenant_id,
-        delete_callback,
-        bandwidth_callback,
-        context,
-        100
+        router_id=cfg.CONF.router_id,
+        tenant_id=router_obj.tenant_id,
+        delete_callback=delete_callback,
+        bandwidth_callback=bandwidth_callback,
+        worker_context=context,
+        queue_warning_threshold=100,
+        reboot_error_threshold=1,
     )
 
     a.send_message(Fake('update'))
@@ -81,4 +83,4 @@ def debug_one_router(args=sys.argv[1:]):
     import pdb
     pdb.set_trace()
 
-    a.update(worker.WorkerContext())
+    a.update(context)

--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -133,9 +133,16 @@ def register_and_load_opts():
 
         cfg.IntOpt(
             'queue_warning_threshold',
-            default=100,
+            default=worker.Worker.QUEUE_WARNING_THRESHOLD_DEFAULT,
             help='warn if the event backlog for a tenant exceeds this value',
-        )
+        ),
+
+        cfg.IntOpt(
+            'reboot_error_threshold',
+            default=worker.Worker.REBOOT_ERROR_THRESHOLD_DEFAULT,
+            help=('Number of reboots to allow before assuming '
+                  'a router needs manual intervention'),
+        ),
 
     ])
 
@@ -248,6 +255,7 @@ def main(argv=sys.argv[1:]):
         notifier=publisher,
         ignore_directory=cfg.CONF.ignored_router_directory,
         queue_warning_threshold=cfg.CONF.queue_warning_threshold,
+        reboot_error_threshold=cfg.CONF.reboot_error_threshold,
     )
 
     # Set up the scheduler that knows how to manage the routers and

--- a/akanda/rug/notifications.py
+++ b/akanda/rug/notifications.py
@@ -96,6 +96,9 @@ def _make_event_from_message(message):
         # Router id is not always present, but look for it as though
         # it is to avoid duplicating this line a few times.
         router_id = message.get('payload', {}).get('router', {}).get('id')
+        if event_type.startswith('routerstatus.update'):
+            # We generate these events ourself, so ignore them.
+            return None
         if event_type == 'router.create.end':
             crud = event.CREATE
         elif event_type == 'router.delete.end':

--- a/akanda/rug/state.py
+++ b/akanda/rug/state.py
@@ -149,6 +149,7 @@ class PushUpdate(State):
     def execute(self, action, worker_context):
         # Put the action back on the front of the queue.
         self.queue.appendleft(UPDATE)
+        return action
 
     def transition(self, action, worker_context):
         return CalcAction(self.params)

--- a/akanda/rug/state.py
+++ b/akanda/rug/state.py
@@ -184,6 +184,9 @@ class CreateVM(State):
             self.vm.set_error(worker_context)
             return action
         self.vm.boot(worker_context)
+        self.log.debug('CreateVM attempt %s/%s',
+                       self.vm.attempts,
+                       self.params.reboot_error_threshold)
         return action
 
     def transition(self, action, worker_context):

--- a/akanda/rug/state.py
+++ b/akanda/rug/state.py
@@ -233,6 +233,10 @@ class StopVM(State):
 
 class RebuildVM(State):
     def execute(self, action, worker_context):
+        # If we are being told explicitly to rebuild the VM, we should
+        # ignore any error status and try to do the rebuild.
+        if self.vm.state == vm_manager.ERROR:
+            self.vm.clear_error(worker_context)
         self.vm.stop(worker_context)
         if self.vm.state == vm_manager.GONE:
             # Force the action to delete since the router isn't there

--- a/akanda/rug/state.py
+++ b/akanda/rug/state.py
@@ -254,7 +254,8 @@ class ReadStats(State):
 class Automaton(object):
     def __init__(self, router_id, tenant_id,
                  delete_callback, bandwidth_callback,
-                 worker_context, queue_warning_threshold):
+                 worker_context, queue_warning_threshold,
+                 reboot_error_threshold):
         """
         :param router_id: UUID of the router being managed
         :type router_id: str
@@ -273,11 +274,15 @@ class Automaton(object):
         :param queue_warning_threshold: Limit after which adding items
                                         to the queue triggers a warning.
         :type queue_warning_threshold: int
+        :param reboot_error_threshold: Limit after which trying to reboot
+                                       the router puts it into an error state.
+        :type reboot_error_threshold: int
         """
         self.router_id = router_id
         self.tenant_id = tenant_id
         self._delete_callback = delete_callback
         self._queue_warning_threshold = queue_warning_threshold
+        self._reboot_error_threshold = reboot_error_threshold
         self.deleted = False
         self.bandwidth_callback = bandwidth_callback
         self._queue = collections.deque()

--- a/akanda/rug/state.py
+++ b/akanda/rug/state.py
@@ -30,10 +30,30 @@ from akanda.rug.event import POLL, CREATE, READ, UPDATE, DELETE, REBUILD
 from akanda.rug import vm_manager
 
 
+class StateParams(object):
+    def __init__(self, vm, log, queue, bandwidth_callback):
+        self.vm = vm
+        self.log = log
+        self.queue = queue
+        self.bandwidth_callback = bandwidth_callback
+
+
 class State(object):
 
-    def __init__(self, log):
-        self.log = log
+    def __init__(self, params):
+        self.params = params
+
+    @property
+    def log(self):
+        return self.params.log
+
+    @property
+    def queue(self):
+        return self.params.queue
+
+    @property
+    def vm(self):
+        return self.params.vm
 
     @property
     def name(self):
@@ -42,15 +62,16 @@ class State(object):
     def __str__(self):
         return self.name
 
-    def execute(self, action, vm, worker_context, queue):
+    def execute(self, action, worker_context):
         return action
 
-    def transition(self, action, vm, worker_context):
+    def transition(self, action, worker_context):
         return self
 
 
 class CalcAction(State):
-    def execute(self, action, vm, worker_context, queue):
+    def execute(self, action, worker_context):
+        queue = self.queue
         if DELETE in queue:
             self.log.debug('shortcutting to delete')
             return DELETE
@@ -105,114 +126,114 @@ class CalcAction(State):
 
         return action
 
-    def transition(self, action, vm, worker_context):
-        if vm.state == vm_manager.GONE:
-            return StopVM(self.log)
+    def transition(self, action, worker_context):
+        if self.vm.state == vm_manager.GONE:
+            return StopVM(self.params)
         elif action == DELETE:
-            return StopVM(self.log)
+            return StopVM(self.params)
         elif action == REBUILD:
-            return RebuildVM(self.log)
-        elif vm.state == vm_manager.BOOTING:
-            return CheckBoot(self.log)
-        elif vm.state == vm_manager.DOWN:
-            return CreateVM(self.log)
+            return RebuildVM(self.params)
+        elif self.vm.state == vm_manager.BOOTING:
+            return CheckBoot(self.params)
+        elif self.vm.state == vm_manager.DOWN:
+            return CreateVM(self.params)
         else:
-            return Alive(self.log)
+            return Alive(self.params)
 
 
 class PushUpdate(State):
     """Put an update instruction on the queue for the state machine.
     """
-    def execute(self, action, vm, worker_context, queue):
+    def execute(self, action, worker_context):
         # Put the action back on the front of the queue.
-        queue.appendleft(UPDATE)
+        self.queue.appendleft(UPDATE)
 
-    def transition(self, action, vm, worker_context):
-        return CalcAction(self.log)
+    def transition(self, action, worker_context):
+        return CalcAction(self.params)
 
 
 class Alive(State):
-    def execute(self, action, vm, worker_context, queue):
-        vm.update_state(worker_context)
+    def execute(self, action, worker_context):
+        self.vm.update_state(worker_context)
         return action
 
-    def transition(self, action, vm, worker_context):
-        if vm.state == vm_manager.GONE:
-            return StopVM(self.log)
-        elif vm.state == vm_manager.DOWN:
-            return CreateVM(self.log)
-        elif action == POLL and vm.state == vm_manager.CONFIGURED:
-            return CalcAction(self.log)
-        elif action == READ and vm.state == vm_manager.CONFIGURED:
-            return ReadStats(self.log)
+    def transition(self, action, worker_context):
+        if self.vm.state == vm_manager.GONE:
+            return StopVM(self.params)
+        elif self.vm.state == vm_manager.DOWN:
+            return CreateVM(self.params)
+        elif action == POLL and self.vm.state == vm_manager.CONFIGURED:
+            return CalcAction(self.params)
+        elif action == READ and self.vm.state == vm_manager.CONFIGURED:
+            return ReadStats(self.params)
         else:
-            return ConfigureVM(self.log)
+            return ConfigureVM(self.params)
 
 
 class CreateVM(State):
-    def execute(self, action, vm, worker_context, queue):
-        vm.boot(worker_context)
+    def execute(self, action, worker_context):
+        self.vm.boot(worker_context)
         return action
 
-    def transition(self, action, vm, worker_context):
-        if vm.state == vm_manager.GONE:
-            return StopVM(self.log)
-        return CheckBoot(self.log)
+    def transition(self, action, worker_context):
+        if self.vm.state == vm_manager.GONE:
+            return StopVM(self.params)
+        return CheckBoot(self.params)
 
 
 class CheckBoot(State):
-    def execute(self, action, vm, worker_context, queue):
-        vm.check_boot(worker_context)
+    def execute(self, action, worker_context):
+        self.vm.check_boot(worker_context)
         # Put the action back on the front of the queue so that we can yield
         # and handle it in another state machine traversal (which will proceed
         # from CalcAction directly to CheckBoot).
-        if vm.state != vm_manager.GONE:
-            queue.appendleft(action)
+        if self.vm.state != vm_manager.GONE:
+            self.queue.appendleft(action)
         return action
 
-    def transition(self, action, vm, worker_context):
-        if vm.state == vm_manager.GONE:
-            return StopVM(self.log)
-        if vm.state == vm_manager.UP:
-            return ConfigureVM(self.log)
-        return CalcAction(self.log)
+    def transition(self, action, worker_context):
+        if self.vm.state == vm_manager.GONE:
+            return StopVM(self.params)
+        if self.vm.state == vm_manager.UP:
+            return ConfigureVM(self.params)
+        return CalcAction(self.params)
 
 
 class StopVM(State):
-    def execute(self, action, vm, worker_context, queue):
-        vm.stop(worker_context)
-        if vm.state == vm_manager.GONE:
+    def execute(self, action, worker_context):
+        self.vm.stop(worker_context)
+        if self.vm.state == vm_manager.GONE:
             # Force the action to delete since the router isn't there
             # any more.
             return DELETE
         return action
 
-    def transition(self, action, vm, worker_context):
-        if vm.state not in (vm_manager.DOWN, vm_manager.GONE):
+    def transition(self, action, worker_context):
+        if self.vm.state not in (vm_manager.DOWN, vm_manager.GONE):
             return self
-        if vm.state == vm_manager.GONE:
-            return Exit(self.log)
+        if self.vm.state == vm_manager.GONE:
+            return Exit(self.params)
         if action == DELETE:
-            return Exit(self.log)
-        return CreateVM(self.log)
+            return Exit(self.params)
+        return CreateVM(self.params)
 
 
 class RebuildVM(State):
-    def execute(self, action, vm, worker_context, queue):
-        vm.stop(worker_context)
-        if vm.state == vm_manager.GONE:
+    def execute(self, action, worker_context):
+        self.vm.stop(worker_context)
+        if self.vm.state == vm_manager.GONE:
             # Force the action to delete since the router isn't there
             # any more.
             return DELETE
         # Re-create the VM
         return CREATE
 
-    def transition(self, action, vm, worker_context):
-        if vm.state not in (vm_manager.DOWN, vm_manager.GONE):
+    def transition(self, action, worker_context):
+        if self.vm.state not in (vm_manager.DOWN, vm_manager.GONE):
             return self
-        if vm.state == vm_manager.GONE:
-            return Exit(self.log)
-        return CreateVM(self.log)
+        if self.vm.state == vm_manager.GONE:
+            return Exit(self.params)
+        return CreateVM(self.params)
 
 
 class Exit(State):
@@ -220,9 +241,9 @@ class Exit(State):
 
 
 class ConfigureVM(State):
-    def execute(self, action, vm, worker_context, queue):
-        vm.configure(worker_context)
-        if vm.state == vm_manager.CONFIGURED:
+    def execute(self, action, worker_context):
+        self.vm.configure(worker_context)
+        if self.vm.state == vm_manager.CONFIGURED:
             if action == READ:
                 return READ
             else:
@@ -230,25 +251,27 @@ class ConfigureVM(State):
         else:
             return action
 
-    def transition(self, action, vm, worker_context):
-        if vm.state in (vm_manager.RESTART, vm_manager.DOWN, vm_manager.GONE):
-            return StopVM(self.log)
-        if vm.state == vm_manager.UP:
-            return PushUpdate(self.log)
+    def transition(self, action, worker_context):
+        if self.vm.state in (vm_manager.RESTART,
+                             vm_manager.DOWN,
+                             vm_manager.GONE):
+            return StopVM(self.params)
+        if self.vm.state == vm_manager.UP:
+            return PushUpdate(self.params)
         # Below here, assume vm.state == vm_manager.CONFIGURED
         if action == READ:
-            return ReadStats(self.log)
-        return CalcAction(self.log)
+            return ReadStats(self.params)
+        return CalcAction(self.params)
 
 
 class ReadStats(State):
-    def execute(self, action, vm, worker_context, queue, bandwidth_callback):
-        stats = vm.read_stats()
-        bandwidth_callback(stats)
+    def execute(self, action, worker_context):
+        stats = self.vm.read_stats()
+        self.params.bandwidth_callback(stats)
         return POLL
 
-    def transition(self, action, vm, worker_context):
-        return CalcAction(self.log)
+    def transition(self, action, worker_context):
+        return CalcAction(self.params)
 
 
 class Automaton(object):
@@ -288,10 +311,16 @@ class Automaton(object):
         self._queue = collections.deque()
         self.log = logging.getLogger(__name__ + '.' + router_id)
 
-        self.state = CalcAction(self.log)
         self.action = POLL
         self.vm = vm_manager.VmManager(router_id, tenant_id, self.log,
                                        worker_context)
+        self._state_params = StateParams(
+            self.vm,
+            self.log,
+            self._queue,
+            self.bandwidth_callback,
+        )
+        self.state = CalcAction(self._state_params)
 
     def service_shutdown(self):
         "Called when the parent process is being stopped"
@@ -316,19 +345,11 @@ class Automaton(object):
                     return
 
                 try:
-                    additional_args = ()
-
-                    if isinstance(self.state, ReadStats):
-                        additional_args = (self.bandwidth_callback,)
-
                     self.log.debug('%s.execute(%s) vm.state=%s',
                                    self.state, self.action, self.vm.state)
                     self.action = self.state.execute(
                         self.action,
-                        self.vm,
                         worker_context,
-                        self._queue,
-                        *additional_args
                     )
                     self.log.debug('%s.execute -> %s vm.state=%s',
                                    self.state, self.action, self.vm.state)
@@ -342,7 +363,6 @@ class Automaton(object):
                 old_state = self.state
                 self.state = self.state.transition(
                     self.action,
-                    self.vm,
                     worker_context,
                 )
                 self.log.debug('%s.transition(%s) -> %s vm.state=%s',

--- a/akanda/rug/state.py
+++ b/akanda/rug/state.py
@@ -412,9 +412,8 @@ class Automaton(object):
 
         if message.crud == POLL and self.vm.state == vm_manager.ERROR:
             self.log.info(
-                'Router status is ERROR, ignoring POLL message '
-                'intended for %s: %s',
-                self.router_id, message,
+                'Router status is ERROR, ignoring POLL message: %s',
+                message,
             )
             return False
 

--- a/akanda/rug/tenant.py
+++ b/akanda/rug/tenant.py
@@ -69,10 +69,13 @@ class TenantRouterManager(object):
     """Keep track of the state machines for the routers for a given tenant.
     """
 
-    def __init__(self, tenant_id, notify_callback, queue_warning_threshold):
+    def __init__(self, tenant_id, notify_callback,
+                 queue_warning_threshold,
+                 reboot_error_threshold):
         self.tenant_id = tenant_id
         self.notify = notify_callback
         self._queue_warning_threshold = queue_warning_threshold
+        self._reboot_error_threshold = reboot_error_threshold
         self.state_machines = RouterContainer()
         self._default_router_id = None
 
@@ -153,6 +156,7 @@ class TenantRouterManager(object):
                 bandwidth_callback=self._report_bandwidth,
                 worker_context=worker_context,
                 queue_warning_threshold=self._queue_warning_threshold,
+                reboot_error_threshold=self._reboot_error_threshold,
             )
             self.state_machines[router_id] = sm
             state_machines = [sm]

--- a/akanda/rug/test/unit/test_debug.py
+++ b/akanda/rug/test/unit/test_debug.py
@@ -35,12 +35,13 @@ class TestDebug(unittest.TestCase):
         ctx.return_value.neutron.get_router_detail.assert_called_once_with('X')
         assert set_trace.called
         automaton.assert_called_once_with(
-            'X',
-            '123',
-            debug.delete_callback,
-            debug.bandwidth_callback,
-            ctx.return_value,
-            100
+            router_id='X',
+            tenant_id='123',
+            delete_callback=debug.delete_callback,
+            bandwidth_callback=debug.bandwidth_callback,
+            worker_context=ctx.return_value,
+            queue_warning_threshold=100,
+            reboot_error_threshold=1,
         )
 
         class CrudMatch(object):

--- a/akanda/rug/test/unit/test_state.py
+++ b/akanda/rug/test/unit/test_state.py
@@ -267,6 +267,34 @@ class TestCreateVMState(BaseTestStateCase):
                                    vm_state=state.vm_manager.ERROR)
 
 
+class TestRebuildVMState(BaseTestStateCase):
+    state_cls = state.RebuildVM
+
+    def test_execute(self):
+        self.assertEqual(
+            self.state.execute('ignored', self.ctx),
+            event.CREATE,
+        )
+        self.vm.stop.assert_called_once_with(self.ctx)
+
+    def test_execute_after_error(self):
+        self.vm.state = vm_manager.ERROR
+        self.assertEqual(
+            self.state.execute('ignored', self.ctx),
+            event.CREATE,
+        )
+        self.vm.stop.assert_called_once_with(self.ctx)
+        self.vm.clear_error.assert_called_once_with(self.ctx)
+
+    def test_execute_gone(self):
+        self.vm.state = vm_manager.GONE
+        self.assertEqual(
+            self.state.execute('ignored', self.ctx),
+            event.DELETE,
+        )
+        self.vm.stop.assert_called_once_with(self.ctx)
+
+
 class TestCheckBootState(BaseTestStateCase):
     state_cls = state.CheckBoot
 

--- a/akanda/rug/test/unit/test_state.py
+++ b/akanda/rug/test/unit/test_state.py
@@ -277,15 +277,6 @@ class TestRebuildVMState(BaseTestStateCase):
         )
         self.vm.stop.assert_called_once_with(self.ctx)
 
-    def test_execute_after_error(self):
-        self.vm.state = vm_manager.ERROR
-        self.assertEqual(
-            self.state.execute('ignored', self.ctx),
-            event.CREATE,
-        )
-        self.vm.stop.assert_called_once_with(self.ctx)
-        self.vm.clear_error.assert_called_once_with(self.ctx)
-
     def test_execute_gone(self):
         self.vm.state = vm_manager.GONE
         self.assertEqual(
@@ -293,6 +284,25 @@ class TestRebuildVMState(BaseTestStateCase):
             event.DELETE,
         )
         self.vm.stop.assert_called_once_with(self.ctx)
+
+
+class TestClearErrorState(BaseTestStateCase):
+    state_cls = state.ClearError
+
+    def test_execute(self):
+        self.assertEqual(
+            self.state.execute('passthrough', self.ctx),
+            'passthrough',
+        )
+        self.vm.clear_error.assert_called_once_with(self.ctx)
+
+    def test_execute_after_error(self):
+        self.vm.state = vm_manager.ERROR
+        self.assertEqual(
+            self.state.execute('passthrough', self.ctx),
+            'passthrough',
+        )
+        self.vm.clear_error.assert_called_once_with(self.ctx)
 
 
 class TestCheckBootState(BaseTestStateCase):

--- a/akanda/rug/test/unit/test_state.py
+++ b/akanda/rug/test/unit/test_state.py
@@ -385,6 +385,7 @@ class TestAutomaton(unittest.TestCase):
             bandwidth_callback=self.bandwidth_callback,
             worker_context=self.ctx,
             queue_warning_threshold=3,
+            reboot_error_threshold=5,
         )
 
     def test_send_message(self):

--- a/akanda/rug/test/unit/test_tenant.py
+++ b/akanda/rug/test/unit/test_tenant.py
@@ -35,6 +35,7 @@ class TestTenantRouterManager(unittest.TestCase):
             '1234',
             notify_callback=self.notifier,
             queue_warning_threshold=10,
+            reboot_error_threshold=5,
         )
         # Establish a fake default router for the tenant for tests
         # that try to use it. We mock out the class above to avoid
@@ -72,7 +73,7 @@ class TestTenantRouterManager(unittest.TestCase):
     def test_all_routers(self):
         self.trm.state_machines.state_machines = {
             str(i): state.Automaton(str(i), '1234',
-                                    None, None, None, 5)
+                                    None, None, None, 5, 5)
             for i in range(5)
         }
         msg = event.Event(

--- a/akanda/rug/test/unit/test_vmmanager.py
+++ b/akanda/rug/test/unit/test_vmmanager.py
@@ -521,7 +521,7 @@ class TestBootAttemptCounter(unittest.TestCase):
         self.c.start()
         self.assertEqual(2, self.c._attempts)
 
-    def test_success(self):
+    def test_reset(self):
         self.c._attempts = 2
-        self.c.success()
+        self.c.reset()
         self.assertEqual(0, self.c._attempts)

--- a/akanda/rug/test/unit/test_vmmanager.py
+++ b/akanda/rug/test/unit/test_vmmanager.py
@@ -492,6 +492,26 @@ class TestVmManager(unittest.TestCase):
                                                                   'ERROR')
         self.assertEqual(vm_manager.ERROR, self.vm_mgr.state)
 
+    def test_clear_error_when_gone(self):
+        self.vm_mgr.state = vm_manager.GONE
+        rtr = mock.sentinel.router
+        rtr.id = 'R1'
+        self.ctx.neutron.get_router_detail.return_value = rtr
+        self.vm_mgr.clear_error(self.ctx)
+        self.quantum.update_router_status.assert_called_once_with('R1',
+                                                                  'ERROR')
+        self.assertEqual(vm_manager.GONE, self.vm_mgr.state)
+
+    def test_set_error_when_error(self):
+        self.vm_mgr.state = vm_manager.ERROR
+        rtr = mock.sentinel.router
+        rtr.id = 'R1'
+        self.ctx.neutron.get_router_detail.return_value = rtr
+        self.vm_mgr.clear_error(self.ctx)
+        self.quantum.update_router_status.assert_called_once_with('R1',
+                                                                  'DOWN')
+        self.assertEqual(vm_manager.DOWN, self.vm_mgr.state)
+
     @mock.patch('time.sleep')
     def test_boot_success_after_error(self, sleep):
         self.next_state = vm_manager.UP

--- a/akanda/rug/test/unit/test_vmmanager.py
+++ b/akanda/rug/test/unit/test_vmmanager.py
@@ -204,6 +204,7 @@ class TestVmManager(unittest.TestCase):
         self.ctx.nova_client.reboot_router_instance.assert_called_once_with(
             self.vm_mgr.router_obj
         )
+        self.assertEqual(1, self.vm_mgr.attempts)
 
     @mock.patch('time.sleep')
     def test_boot_fail(self, sleep):
@@ -220,6 +221,7 @@ class TestVmManager(unittest.TestCase):
         self.ctx.nova_client.reboot_router_instance.assert_called_once_with(
             self.vm_mgr.router_obj
         )
+        self.assertEqual(1, self.vm_mgr.attempts)
 
     @mock.patch('time.sleep')
     def test_boot_with_port_cleanup(self, sleep):
@@ -476,7 +478,8 @@ class TestVmManager(unittest.TestCase):
         rtr.id = 'R1'
         self.ctx.neutron.get_router_detail.return_value = rtr
         self.vm_mgr.set_error(self.ctx)
-        self.quantum.update_router_status.assert_called_once_with('R1', 'ERROR')
+        self.quantum.update_router_status.assert_called_once_with('R1',
+                                                                  'ERROR')
         self.assertEqual(vm_manager.GONE, self.vm_mgr.state)
 
     def test_set_error_when_booting(self):
@@ -485,7 +488,8 @@ class TestVmManager(unittest.TestCase):
         rtr.id = 'R1'
         self.ctx.neutron.get_router_detail.return_value = rtr
         self.vm_mgr.set_error(self.ctx)
-        self.quantum.update_router_status.assert_called_once_with('R1', 'ERROR')
+        self.quantum.update_router_status.assert_called_once_with('R1',
+                                                                  'ERROR')
         self.assertEqual(vm_manager.ERROR, self.vm_mgr.state)
 
     @mock.patch('time.sleep')
@@ -504,7 +508,6 @@ class TestVmManager(unittest.TestCase):
         self.ctx.nova_client.reboot_router_instance.assert_called_once_with(
             self.vm_mgr.router_obj
         )
-
 
 
 class TestBootAttemptCounter(unittest.TestCase):

--- a/akanda/rug/test/unit/test_vmmanager.py
+++ b/akanda/rug/test/unit/test_vmmanager.py
@@ -130,6 +130,46 @@ class TestVmManager(unittest.TestCase):
     @mock.patch('time.sleep')
     @mock.patch('akanda.rug.vm_manager.router_api')
     @mock.patch('akanda.rug.vm_manager._get_management_address')
+    def test_boot_timeout_error(self, get_mgt_addr, router_api, sleep):
+        self.vm_mgr.state = vm_manager.ERROR
+        self.vm_mgr.last_boot = datetime.utcnow()
+        self.update_state_p.stop()
+        get_mgt_addr.return_value = 'fe80::beef'
+        router_api.is_alive.return_value = False
+
+        self.assertEqual(
+            self.vm_mgr.update_state(self.ctx),
+            vm_manager.ERROR,
+        )
+        router_api.is_alive.assert_has_calls([
+            mock.call('fe80::beef', 5000),
+            mock.call('fe80::beef', 5000),
+            mock.call('fe80::beef', 5000)
+        ])
+
+    @mock.patch('time.sleep')
+    @mock.patch('akanda.rug.vm_manager.router_api')
+    @mock.patch('akanda.rug.vm_manager._get_management_address')
+    def test_boot_timeout_error_no_last_boot(self, get_mgt_addr, router_api, sleep):
+        self.vm_mgr.state = vm_manager.ERROR
+        self.vm_mgr.last_boot = None
+        self.update_state_p.stop()
+        get_mgt_addr.return_value = 'fe80::beef'
+        router_api.is_alive.return_value = False
+
+        self.assertEqual(
+            self.vm_mgr.update_state(self.ctx),
+            vm_manager.ERROR,
+        )
+        router_api.is_alive.assert_has_calls([
+            mock.call('fe80::beef', 5000),
+            mock.call('fe80::beef', 5000),
+            mock.call('fe80::beef', 5000)
+        ])
+
+    @mock.patch('time.sleep')
+    @mock.patch('akanda.rug.vm_manager.router_api')
+    @mock.patch('akanda.rug.vm_manager._get_management_address')
     def test_boot_timeout(self, get_mgt_addr, router_api, sleep):
         self.vm_mgr.last_boot = datetime.utcnow() - timedelta(minutes=5)
         self.update_state_p.stop()

--- a/akanda/rug/test/unit/test_vmmanager.py
+++ b/akanda/rug/test/unit/test_vmmanager.py
@@ -469,3 +469,20 @@ class TestVmManager(unittest.TestCase):
         self.assertEqual(self.vm_mgr._ensure_provider_ports(rtr, self.ctx),
                          rtr)
         self.quantum.create_router_external_port.assert_called_once_with(rtr)
+
+
+class TestBootAttemptCounter(unittest.TestCase):
+
+    def setUp(self):
+        self.c = vm_manager.BootAttemptCounter()
+
+    def test_start(self):
+        self.c.start()
+        self.assertEqual(1, self.c._attempts)
+        self.c.start()
+        self.assertEqual(2, self.c._attempts)
+
+    def test_success(self):
+        self.c._attempts = 2
+        self.c.success()
+        self.assertEqual(0, self.c._attempts)

--- a/akanda/rug/test/unit/test_vmmanager.py
+++ b/akanda/rug/test/unit/test_vmmanager.py
@@ -150,7 +150,8 @@ class TestVmManager(unittest.TestCase):
     @mock.patch('time.sleep')
     @mock.patch('akanda.rug.vm_manager.router_api')
     @mock.patch('akanda.rug.vm_manager._get_management_address')
-    def test_boot_timeout_error_no_last_boot(self, get_mgt_addr, router_api, sleep):
+    def test_boot_timeout_error_no_last_boot(self, get_mgt_addr, router_api,
+                                             sleep):
         self.vm_mgr.state = vm_manager.ERROR
         self.vm_mgr.last_boot = None
         self.update_state_p.stop()

--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -61,7 +61,7 @@ class BootAttemptCounter(object):
     def start(self):
         self._attempts += 1
 
-    def success(self):
+    def reset(self):
         self._attempts = 0
 
     @property
@@ -141,7 +141,7 @@ class VmManager(object):
             # Always reset the boot counter, even if we didn't boot
             # the server ourself, so we don't accidentally think we
             # have an erroring router.
-            self._boot_counter.success()
+            self._boot_counter.reset()
         return self.state
 
     def boot(self, worker_context):

--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -112,13 +112,23 @@ class VmManager(object):
                 )
             time.sleep(cfg.CONF.retry_delay)
         else:
-            self.state = DOWN
+            # Do not reset the state if we have an error condition
+            # already. The state will be reset when the router starts
+            # responding again, or when the error is cleared from a
+            # forced rebuild.
+            if self.state != ERROR:
+                self.state = DOWN
             if self.last_boot:
                 seconds_since_boot = (
                     datetime.utcnow() - self.last_boot
                 ).total_seconds()
                 if seconds_since_boot < cfg.CONF.boot_timeout:
-                    self.state = BOOTING
+                    # Do not reset the state if we have an error
+                    # condition already. The state will be reset when
+                    # the router starts responding again, or when the
+                    # error is cleared from a forced rebuild.
+                    if self.state != ERROR:
+                        self.state = BOOTING
                 else:
                     # If the VM was created more than `boot_timeout` seconds
                     # ago, log an error and leave the state set to DOWN

--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -204,6 +204,24 @@ class VmManager(object):
         self.state = ERROR
         return self.state
 
+    @synchronize_router_status
+    def clear_error(self, worker_context, silent=False):
+        """Clear the internal error state.
+
+        This is called from outside when something wants to force a
+        router rebuild, so that the state machine that checks our
+        status won't think we are broken unless we actually break
+        again.
+        """
+        # Clear the boot counter.
+        self._boot_counter.reset()
+        self._ensure_cache(worker_context)
+        if self.state == GONE:
+            self.log.debug('not updating state of deleted router')
+            return self.state
+        self.state = DOWN
+        return self.state
+
     def stop(self, worker_context):
         self._ensure_cache(worker_context)
         if self.state == GONE:

--- a/akanda/rug/worker.py
+++ b/akanda/rug/worker.py
@@ -57,13 +57,18 @@ class Worker(object):
     method of an instance of this class instead of a simple function.
     """
 
+    QUEUE_WARNING_THRESHOLD_DEFAULT = 100
+    REBOOT_ERROR_THRESHOLD_DEFAULT = 5
+
     def __init__(self,
                  num_threads,
                  notifier,
                  ignore_directory=None,
-                 queue_warning_threshold=100):
+                 queue_warning_threshold=QUEUE_WARNING_THRESHOLD_DEFAULT,
+                 reboot_error_threshold=REBOOT_ERROR_THRESHOLD_DEFAULT):
         self._ignore_directory = ignore_directory
         self._queue_warning_threshold = queue_warning_threshold
+        self._reboot_error_threshold = reboot_error_threshold
         self.work_queue = Queue.Queue()
         self.lock = threading.Lock()
         self._keep_going = True
@@ -205,6 +210,7 @@ class Worker(object):
                 tenant_id=tenant_id,
                 notify_callback=self.notifier.publish,
                 queue_warning_threshold=self._queue_warning_threshold,
+                reboot_error_threshold=self._reboot_error_threshold,
             )
         return [self.tenant_managers[tenant_id]]
 

--- a/doc/source/state_machine.dot
+++ b/doc/source/state_machine.dot
@@ -19,6 +19,7 @@ digraph rug {
   CALC_ACTION -> CHECK_BOOT [ label = "ACT>[CRUP],vm:B" ];
   CALC_ACTION -> REBUILD_VM [ label = "ACT:E" ];
   CALC_ACTION -> STOP_VM [ label = "ACT>D or vm:G" ];
+  CALC_ACTION -> CLEAR_ERROR [ label = "vm:E" ];
 
   ALIVE -> CREATE_VM [ label = "vm>D" ];
   ALIVE -> CONFIG [ label = "ACT:[CU],vm:[UC]" ];
@@ -39,6 +40,8 @@ digraph rug {
   CONFIG -> STOP_VM [ label = "vm>[RDG]" ];
 
   STATS -> CALC_ACTION [ label = "ACT>P" ];
+
+  CLEAR_ERROR -> CALC_ACTION;
 
   REBUILD_VM -> REBUILD_VM [ label = "vm!=[DG]" ];
   REBUILD_VM -> CREATE_VM [ label = "ACT:E,vm:D" ];

--- a/doc/source/state_machine.dot
+++ b/doc/source/state_machine.dot
@@ -28,6 +28,7 @@ digraph rug {
 
   CREATE_VM -> CHECK_BOOT [ label = "ACT:[CRUDP],vm:[DBUCR]" ];
   CREATE_VM -> STOP_VM [ label = "vm:G" ];
+  CREATE_VM -> CALC_ACTION [ label = "vm:E" ];
 
   CHECK_BOOT -> CONFIG [ label = "vm>U" ];
   CHECK_BOOT -> CALC_ACTION [ label = "vm:[DBCR]" ];

--- a/doc/source/state_machine.rst
+++ b/doc/source/state_machine.rst
@@ -35,3 +35,5 @@ vm Variable
 :Configured: VM is known to be configured.
 :Restart Needed: VM needs to be rebooted.
 :Gone: The router definition has been removed from neutron.
+:Error: The router has been rebooted too many times, or has had some
+        other error.

--- a/doc/source/state_machine.rst
+++ b/doc/source/state_machine.rst
@@ -9,6 +9,7 @@ States
 
 :CALC_ACTION: Coalesces the pending actions from the queue inside the state machine.
 :ALIVE: Checks whether the instance is alive.
+:CLEAR_ERROR: Clear the error status before attempting any further operation.
 :STATS: Reads traffic data from the router.
 :CREATE_VM: Makes a new VM instance.
 :CHECKBOOT: Check if a new VM instance has been booted and initially configured.


### PR DESCRIPTION
This patch series includes several changes related to making the RUG
detect reboot loops for routers and then stop thrashing on them.

DHC-2147
