### PR TITLE
Make ClearError bypass second CalcAction

### DIFF
--- a/doc/source/state_machine.dot
+++ b/doc/source/state_machine.dot
@@ -41,7 +41,7 @@ digraph rug {
 
   STATS -> CALC_ACTION [ label = "ACT>P" ];
 
-  CLEAR_ERROR -> CALC_ACTION;
+  CLEAR_ERROR -> CALC_ACTION [ label = "no pause before next action" ];
 
   REBUILD_VM -> REBUILD_VM [ label = "vm!=[DG]" ];
   REBUILD_VM -> CREATE_VM [ label = "ACT:E,vm:D" ];


### PR DESCRIPTION
When CalcAction determines that the router has an error status, it
transitions to ClearError, which returns to CalcAction. Each time we make it
back to CalcAction, we yield control of the worker and have to wait for
another turn. Since we know we're going to re-compute the same action, just
pass it to ClearError and allow that state to transition directly to the next
real update, bypassing CalcAction.

Change-Id: I5bd28403d679889158f28e6440eab7e3b50318d7
