### PR TITLE
Change router commands to take router id

### DIFF
--- a/akanda/rug/cli/router.py
+++ b/akanda/rug/cli/router.py
@@ -22,6 +22,8 @@ import logging
 from akanda.rug import commands
 from akanda.rug.cli import message
 
+from neutronclient.v2_0 import client
+
 
 class _RouterCmd(message.MessageSending):
 
@@ -65,25 +67,45 @@ class _TenantRouterCmd(_RouterCmd):
         # argument first
         p = super(_RouterCmd, self).get_parser(prog_name)
         p.add_argument(
-            'tenant_id',
-        )
-        p.add_argument(
             'router_id',
-            nargs='?',
         )
         return p
 
     def make_message(self, parsed_args):
+        router_id = parsed_args.router_id
+        # Look up the tenant for a given router so we can send the
+        # command using both and the rug can route it to the correct
+        # worker. We do the lookup here instead of in the rug to avoid
+        # having to teach the rug notification and dispatching code
+        # about how to find the owner of a router, and to shift the
+        # burden of the neutron API call to the client so the server
+        # doesn't block. It also gives us a chance to report an error
+        # when we can't find the router.
+        n_c = client.Client(
+            username=self.app.rug_ini.admin_user,
+            password=self.app.rug_ini.admin_password,
+            tenant_name=self.app.rug_ini.admin_tenant_name,
+            auth_url=self.app.rug_ini.auth_url,
+            auth_strategy=self.app.rug_ini.auth_strategy,
+            auth_region=self.app.rug_ini.auth_region,
+        )
+        response = n_c.list_routers(router_id=router_id)
+        try:
+            router_details = response['routers'][0]
+        except (KeyError, IndexError):
+            raise ValueError('No router with id %r found: %s' %
+                             (router_id, response))
+        tenant_id = router_details['tenant_id']
         self.log.info(
             'sending %s instruction for tenant %r, router with uuid %r',
             self._COMMAND,
-            parsed_args.tenant_id,
-            parsed_args.router_id,
+            tenant_id,
+            router_id,
         )
         return {
             'command': self._COMMAND,
-            'router_id': parsed_args.router_id,
-            'tenant_id': parsed_args.tenant_id,
+            'router_id': router_id,
+            'tenant_id': tenant_id,
         }
 
 


### PR DESCRIPTION
The fact that the commands to debug and manage a router take a tenant id as
argument has been a constant source of confusion. Fix it by making them take
a router id and look up the tenant id.

Change-Id: I7f05319eb854b1b9b4b99fd6e76c778866bcf87a
