### PR TITLE
Always send a tenant id when sending a router command

### DIFF
--- a/akanda/rug/cli/app.py
+++ b/akanda/rug/cli/app.py
@@ -40,6 +40,8 @@ class RugController(app.App):
         )
 
     def initialize_app(self, argv):
+        # Quiet logging for some request library
+        logging.getLogger('requests').setLevel(logging.WARN)
         main.register_and_load_opts()
         # Don't pass argv here because cfg.CONF will intercept the
         # help options and exit.

--- a/akanda/rug/cli/router.py
+++ b/akanda/rug/cli/router.py
@@ -17,55 +17,18 @@
 
 """Commands related to routers.
 """
-import logging
-
 from akanda.rug import commands
 from akanda.rug.cli import message
 
 from neutronclient.v2_0 import client
 
 
-class _RouterCmd(message.MessageSending):
-
-    log = logging.getLogger(__name__)
-
-    def get_parser(self, prog_name):
-        p = super(_RouterCmd, self).get_parser(prog_name)
-        p.add_argument(
-            'router_id',
-        )
-        return p
-
-    def make_message(self, parsed_args):
-        self.log.info(
-            'sending %s instruction for router with uuid %r',
-            self._COMMAND,
-            parsed_args.router_id,
-        )
-        return {
-            'command': self._COMMAND,
-            'router_id': parsed_args.router_id,
-        }
-
-
-class RouterDebug(_RouterCmd):
-    """debug a single router"""
-
-    _COMMAND = commands.ROUTER_DEBUG
-
-
-class RouterManage(_RouterCmd):
-    """manage a single router"""
-
-    _COMMAND = commands.ROUTER_MANAGE
-
-
-class _TenantRouterCmd(_RouterCmd):
+class _TenantRouterCmd(message.MessageSending):
 
     def get_parser(self, prog_name):
         # Bypass the direct base class to let us put the tenant id
         # argument first
-        p = super(_RouterCmd, self).get_parser(prog_name)
+        p = super(_TenantRouterCmd, self).get_parser(prog_name)
         p.add_argument(
             'router_id',
         )
@@ -122,3 +85,15 @@ class RouterRebuild(_TenantRouterCmd):
     """force-rebuild a router"""
 
     _COMMAND = commands.ROUTER_REBUILD
+
+
+class RouterDebug(_TenantRouterCmd):
+    """debug a single router"""
+
+    _COMMAND = commands.ROUTER_DEBUG
+
+
+class RouterManage(_TenantRouterCmd):
+    """manage a single router"""
+
+    _COMMAND = commands.ROUTER_MANAGE


### PR DESCRIPTION
Now that we have a class in the CLI that knows how to look up a router id and
get the tenant id, always use it. That should avoid having spurious messages
for debugging and managing routers ending up in the wrong worker process.

Change-Id: I21edc898d5d94ced3af8db375cf4d919ba3c6e68
