### PR TITLE
fix call to list_routers()

### DIFF
--- a/akanda/rug/cli/router.py
+++ b/akanda/rug/cli/router.py
@@ -58,7 +58,7 @@ class _TenantRouterCmd(message.MessageSending):
                 auth_strategy=self.app.rug_ini.auth_strategy,
                 auth_region=self.app.rug_ini.auth_region,
             )
-            response = n_c.list_routers(router_id=router_id)
+            response = n_c.list_routers(True, id=router_id)
             try:
                 router_details = response['routers'][0]
             except (KeyError, IndexError):


### PR DESCRIPTION
Previously, we tried doing list_routers(router_id=blah), which
would result in novaclient always returning every router, with
no filtering.  Fix that so we only get the router we're looking
for.
