### PR TITLE
Support for local external port configuration

### DIFF
--- a/akanda/rug/api/quantum.py
+++ b/akanda/rug/api/quantum.py
@@ -556,7 +556,7 @@ class Quantum(object):
             time.sleep(1)
 
         driver.init_l3(driver.get_device_name(port), [ip_address])
-    return port
+        return port
 
     def ensure_local_service_port(self):
         driver = importutils.import_object(self.conf.interface_driver,

--- a/akanda/rug/api/quantum.py
+++ b/akanda/rug/api/quantum.py
@@ -510,6 +510,54 @@ class Quantum(object):
             )
         return new_port
 
+    def ensure_local_external_port(self):
+        driver = importutils.import_object(self.conf.interface_driver,
+                                           self.conf)
+
+        host_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, socket.gethostname()))
+
+        query_dict = dict(device_owner=DEVICE_OWNER_RUG,
+                          device_id=host_id,
+			  network_id=self.conf.external_network_id,
+			 )
+        ports = self.api_client.list_ports(**query_dict)['ports']
+
+        ip_address = get_local_external_ip(self.conf)
+
+        if ports:
+            port = Port.from_dict(ports[0])
+            LOG.info('already have local external port, using %r', port)
+        else:
+            LOG.info('creating a new local external port')
+            port_dict = dict(
+                admin_state_up=True,
+                network_id=self.conf.external_network_id,
+                device_owner=DEVICE_OWNER_RUG,
+                device_id=host_id,
+                fixed_ips=[{
+                    'ip_address': ip_address.split('/')[0],
+                    'subnet_id': self.conf.external_subnet_id
+                }]
+            )
+
+            port = Port.from_dict(
+                self.api_client.create_port(dict(port=port_dict))['port'])
+            LOG.info('new local gateway port: %r', port)
+
+        # create the tap interface if it doesn't already exist
+        if not ip_lib.device_exists(driver.get_device_name(port)):
+            driver.plug(
+                port.network_id,
+                port.id,
+                driver.get_device_name(port),
+                port.mac_address)
+
+            # add sleep to ensure that port is setup before use
+            time.sleep(1)
+
+        driver.init_l3(driver.get_device_name(port), [ip_address])
+	return port
+
     def ensure_local_service_port(self):
         driver = importutils.import_object(self.conf.interface_driver,
                                            self.conf)
@@ -517,7 +565,9 @@ class Quantum(object):
         host_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, socket.gethostname()))
 
         query_dict = dict(device_owner=DEVICE_OWNER_RUG,
-                          device_id=host_id)
+                          device_id=host_id,
+			  network_id=self.conf.management_network_id,
+			)
 
         ports = self.api_client.list_ports(**query_dict)['ports']
 
@@ -594,3 +644,9 @@ def get_local_service_ip(conf):
     rug_ip = '%s/%s' % (netaddr.IPAddress(mgt_net.first + 1),
                         mgt_net.prefixlen)
     return rug_ip
+
+def get_local_external_ip(conf):
+    external_net = netaddr.IPNetwork(conf.external_prefix)
+    external_ip = '%s/%s' % (netaddr.IPAddress(external_net.first + 1),
+                        external_net.prefixlen)
+    return external_ip

--- a/akanda/rug/api/quantum.py
+++ b/akanda/rug/api/quantum.py
@@ -518,7 +518,7 @@ class Quantum(object):
 
         query_dict = dict(device_owner=DEVICE_OWNER_RUG,
                           device_id=host_id,
-			  network_id=self.conf.external_network_id,
+                          network_id=self.conf.external_network_id,
 			 )
         ports = self.api_client.list_ports(**query_dict)['ports']
 
@@ -556,7 +556,7 @@ class Quantum(object):
             time.sleep(1)
 
         driver.init_l3(driver.get_device_name(port), [ip_address])
-	return port
+    return port
 
     def ensure_local_service_port(self):
         driver = importutils.import_object(self.conf.interface_driver,
@@ -566,8 +566,7 @@ class Quantum(object):
 
         query_dict = dict(device_owner=DEVICE_OWNER_RUG,
                           device_id=host_id,
-			  network_id=self.conf.management_network_id,
-			)
+                          network_id=self.conf.management_network_id)
 
         ports = self.api_client.list_ports(**query_dict)['ports']
 

--- a/akanda/rug/api/quantum.py
+++ b/akanda/rug/api/quantum.py
@@ -518,8 +518,8 @@ class Quantum(object):
 
         query_dict = dict(device_owner=DEVICE_OWNER_RUG,
                           device_id=host_id,
-                          network_id=self.conf.external_network_id,
-			 )
+                          network_id=self.conf.external_network_id)
+
         ports = self.api_client.list_ports(**query_dict)['ports']
 
         ip_address = get_local_external_ip(self.conf)
@@ -644,8 +644,9 @@ def get_local_service_ip(conf):
                         mgt_net.prefixlen)
     return rug_ip
 
+
 def get_local_external_ip(conf):
     external_net = netaddr.IPNetwork(conf.external_prefix)
     external_ip = '%s/%s' % (netaddr.IPAddress(external_net.first + 1),
-                        external_net.prefixlen)
+                             external_net.prefixlen)
     return external_ip

--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -122,7 +122,7 @@ def register_and_load_opts():
         cfg.BoolOpt('ovs_use_veth', default=False),
         cfg.IntOpt('network_device_mtu'),
 
-	# plug in the external port locally
+        # plug in the external port locally
         cfg.BoolOpt('plug_external_port', default=False),
 
         # needed for boot waiting

--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -108,9 +108,11 @@ def register_and_load_opts():
         cfg.StrOpt('management_network_id'),
         cfg.StrOpt('external_network_id'),
         cfg.StrOpt('management_subnet_id'),
+        cfg.StrOpt('external_subnet_id'),
         cfg.StrOpt('router_image_uuid'),
 
         cfg.StrOpt('management_prefix', default='fdca:3ba5:a17a:acda::/64'),
+        cfg.StrOpt('external_prefix', default='172.16.77.0/24'),
         cfg.IntOpt('akanda_mgt_service_port', default=5000),
         cfg.IntOpt('router_instance_flavor', default=1),
 
@@ -119,6 +121,9 @@ def register_and_load_opts():
         cfg.StrOpt('ovs_integration_bridge', default='br-int'),
         cfg.BoolOpt('ovs_use_veth', default=False),
         cfg.IntOpt('network_device_mtu'),
+
+	# plug in the external port locally
+        cfg.BoolOpt('plug_external_port', default=False),
 
         # needed for boot waiting
         cfg.IntOpt('boot_timeout', default=600),
@@ -210,6 +215,10 @@ def main(argv=sys.argv[1:]):
 
     # bring the mgt tap interface up
     quantum.ensure_local_service_port()
+
+    # bring the external port
+    if cfg.CONF.plug_external_port:
+        quantum.ensure_local_external_port()
 
     # Set up the queue to move messages between the eventlet-based
     # listening process and the scheduler.

--- a/etc/rug.ini
+++ b/etc/rug.ini
@@ -14,6 +14,9 @@ akanda_mgt_service_port=5000
 management_network_id=dca21cbf-fc11-4d0f-86a8-b856e95b0d1b
 management_subnet_id=92607c63-0738-4e19-a1c8-f770a1dd48fd
 external_network_id=fbf6b360-be38-48cd-bce3-6a9b710b3cc9
+external_subnet_id=f3803915-dd28-487c-81a7-b109ab13e2ee
+external_prefix=172.16.77.0/24
+plug_external_port=True
 
 router_image_uuid=1e9c16f3-e070-47b7-b49c-ffcf38df5f9a
 router_instance_flavor=1


### PR DESCRIPTION
Add's ensure_local_external_port which sets up an external gateway
tap the same way we do for the management network.

New config options
- external_subnet_id
- external_prefix (default 172.16.77.0/24)
- plug_external_port (default False)
