### PR TITLE
Improve `rug-ctl browse` for large-scale deployments with 500+ routers.

### DIFF
--- a/akanda/rug/api/quantum.py
+++ b/akanda/rug/api/quantum.py
@@ -96,7 +96,7 @@ class Router(object):
         management_port = None
         internal_ports = []
 
-        for port_dict in d['ports']:
+        for port_dict in d.get('ports', []):
             port = Port.from_dict(port_dict)
             if port.device_owner == DEVICE_OWNER_ROUTER_GW:
                 external_port = port
@@ -398,10 +398,13 @@ class Quantum(object):
         )
         self.rpc_client = L3PluginApi(PLUGIN_RPC_TOPIC, cfg.CONF.host)
 
-    def get_routers(self):
+    def get_routers(self, detailed=True):
         """Return a list of routers."""
-        return [Router.from_dict(r) for r in
-                self.rpc_client.get_routers()]
+        if detailed:
+            return [Router.from_dict(r) for r in
+                    self.rpc_client.get_routers()]
+        routers = self.api_client.list_routers().get('routers', [])
+        return [Router.from_dict(r) for r in routers]
 
     def get_router_detail(self, router_id):
         """Return detailed information about a router and it's networks."""


### PR DESCRIPTION
- Don't use RPC to list routers; this is expensive in the scale of data returned.  Instead, retrieve a list
  of limited data via the REST API.
- Bump up the number of default `nova show` workers to something reasonable
  (and make the number of threads configurable).
- Lower the frequency of SQL SELECT queries from every 1 second to every
  3 seconds to avoid overwhelming SQLite.
- Don't spawn a separate subprocess for router fetching, but instead use
  a thread; in some versions of Python, using Python's multiprocessing module
  results in odd segfaults related to our curses library.
- Sort the routers by ID so that the appliance VM details start to appear at
  the top of the list (the default view at startup) by default.
