### PR TITLE
Always attempt to clean port device_id's on reboot

### DIFF
--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -185,7 +185,8 @@ class VmManager(object):
             # the newly created akanda instance (and fails).
             router = self.router_obj
             for p in router.ports:
-                worker_context.neutron.clear_device_id(p)
+                if p.device_id:
+                    worker_context.neutron.clear_device_id(p)
             created = worker_context.nova_client.reboot_router_instance(
                 router,
                 router_image_uuid

--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -178,16 +178,14 @@ class VmManager(object):
 
             # In the event that the current akanda instance isn't deleted
             # cleanly (which we've seen in certain circumstances, like
-            # hypervisor failures), be proactive and attempt to clean up the
-            # router ports manually.  This helps avoid a situation where the
-            # rug repeatedly attempts to plug stale router ports into the newly
-            # created akanda instance (and fails).
+            # hypervisor failures), or the vm has alredy been deleted but
+            # device_id is still set incorrectly, be proactive and attempt to
+            # clean up the router ports manually.  This helps avoid a situation
+            # where the rug repeatedly attempts to plug stale router ports into
+            # the newly created akanda instance (and fails).
             router = self.router_obj
-            instance = worker_context.nova_client.get_instance(router)
-            if instance is not None:
-                for p in router.ports:
-                    if p.device_id == instance.id:
-                        worker_context.neutron.clear_device_id(p)
+            for p in router.ports:
+                worker_context.neutron.clear_device_id(p)
             created = worker_context.nova_client.reboot_router_instance(
                 router,
                 router_image_uuid


### PR DESCRIPTION
Recently I have come across a few cases where device_id is still set to
an id that does not exist anymore. Somehow the vm was shut down previously
and the port device_id did not get cleaned properly. This change will force the
rug clear device_id on all router ports before a reboot is attempted.
