### PR TITLE
Allow is_alive timeout to be configured

### DIFF
--- a/akanda/rug/api/akanda_client.py
+++ b/akanda/rug/api/akanda_client.py
@@ -17,6 +17,7 @@
 
 import requests
 
+from oslo.config import cfg
 from akanda.rug.openstack.common import jsonutils
 
 AKANDA_ULA_PREFIX = 'fdca:3ba5:a17a:acda::/64'
@@ -41,7 +42,7 @@ def is_alive(host, port):
     path = AKANDA_BASE_PATH + 'firewall/rules'
     try:
         s = _get_proxyless_session()
-        r = s.get(_mgt_url(host, port, path), timeout=3.0)
+        r = s.get(_mgt_url(host, port, path), timeout=cfg.CONF.alive_timeout)
         if r.status_code == 200:
             return True
     except:

--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -133,6 +133,7 @@ def register_and_load_opts():
         cfg.IntOpt('boot_timeout', default=600),
         cfg.IntOpt('max_retries', default=3),
         cfg.IntOpt('retry_delay', default=1),
+        cfg.IntOpt('alive_timeout', default=3),
 
         cfg.StrOpt(
             'ignored_router_directory',


### PR DESCRIPTION
This allows you to control the isalive check timeout with
the option "alive_timeout = (num of seconds)"
