### PR TITLE
Fix wildcard router operations

### DIFF
--- a/akanda/rug/cli/router.py
+++ b/akanda/rug/cli/router.py
@@ -41,6 +41,8 @@ class _TenantRouterCmd(message.MessageSending):
         router_id = parsed_args.router_id.lower()
         if router_id == 'error':
             tenant_id = 'error'
+        elif router_id == '*':
+            tenant_id = '*'
         else:
             # Look up the tenant for a given router so we can send the
             # command using both and the rug can route it to the correct


### PR DESCRIPTION
This was inadvertently broken back in July by commit
f13da7f2658380388cf9639a314ebbe8c7fd591a.  This change should return
the ability to issue commands on wildcard routers.
