### PR TITLE
Properly clean up router VMs when they're removed from Neutron.

### DIFF
--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -272,6 +272,7 @@ class VmManager(object):
                 tenant_id=self.tenant_id,
                 name='unnamed',
                 admin_state_up=False,
+                status=quantum.STATUS_DOWN
             )
             self.log.info('Destroying router neutron has deleted')
         else:


### PR DESCRIPTION
This is something I unintentionally broke awhile back (there wasn't a test for it):

https://github.com/dreamhost/akanda-rug/commit/272a42ada879bfed2b9910ef9aef7663b7aba76f
https://github.com/dreamhost/akanda-rug/commit/272a42ada879bfed2b9910ef9aef7663b7aba76f#diff-671f5dab54e3322917499496cdb8cbeeR69
