### PR TITLE
Return value if synchronizing port on delete

### DIFF
--- a/akanda/rug/test/unit/test_vmmanager.py
+++ b/akanda/rug/test/unit/test_vmmanager.py
@@ -874,26 +874,32 @@ class TestSynchronizeRouterStatus(unittest.TestCase):
 
     def test_router_is_deleted(self):
         self.test_vm_manager.router_obj = None
-        v = vm_manager.synchronize_router_status(lambda vm_manager_inst, ctx, silent: 1)
+        v = vm_manager.synchronize_router_status(
+            lambda vm_manager_inst, ctx, silent: 1)
         self.assertEqual(v(self.test_vm_manager, {}), 1)
 
     def test_router_status_changed(self):
         self.test_vm_manager.router_obj = mock.Mock(id='ABC123')
         self.test_vm_manager._last_synced_status = quantum.STATUS_ACTIVE
         self.test_vm_manager.state = vm_manager.DOWN
-        v = vm_manager.synchronize_router_status(lambda vm_manager_inst, ctx, silent: 1)
+        v = vm_manager.synchronize_router_status(
+            lambda vm_manager_inst, ctx, silent: 1)
         self.assertEqual(v(self.test_vm_manager, self.test_context), 1)
-        self.test_context.neutron.update_router_status.assert_called_once_with(
-            'ABC123',
-            quantum.STATUS_DOWN
-        )
-        self.assertEqual(self.test_vm_manager._last_synced_status, quantum.STATUS_DOWN)
+        self.test_context.neutron.update_router_status.\
+            assert_called_once_with(
+                'ABC123',
+                quantum.STATUS_DOWN)
+        self.assertEqual(self.test_vm_manager._last_synced_status,
+                         quantum.STATUS_DOWN)
 
     def test_router_status_same(self):
         self.test_vm_manager.router_obj = mock.Mock(id='ABC123')
         self.test_vm_manager._last_synced_status = quantum.STATUS_ACTIVE
         self.test_vm_manager.state = vm_manager.CONFIGURED
-        v = vm_manager.synchronize_router_status(lambda vm_manager_inst, ctx, silent: 1)
+        v = vm_manager.synchronize_router_status(
+            lambda vm_manager_inst, ctx, silent: 1)
         self.assertEqual(v(self.test_vm_manager, self.test_context), 1)
-        self.assertEqual(self.test_context.neutron.update_router_status.call_count, 0)
-        self.assertEqual(self.test_vm_manager._last_synced_status, quantum.STATUS_ACTIVE)
+        self.assertEqual(
+            self.test_context.neutron.update_router_status.call_count, 0)
+        self.assertEqual(
+            self.test_vm_manager._last_synced_status, quantum.STATUS_ACTIVE)

--- a/akanda/rug/vm_manager.py
+++ b/akanda/rug/vm_manager.py
@@ -49,6 +49,8 @@ def synchronize_router_status(f):
     def wrapper(self, worker_context, silent=False):
         old_status = self._last_synced_status
         val = f(self, worker_context, silent)
+        if not self.router_obj:
+            return val
         new_status = STATUS_MAP.get(self.state, quantum.STATUS_ERROR)
         if not old_status or old_status != new_status:
             worker_context.neutron.update_router_status(


### PR DESCRIPTION
There exists a case when the rug is deleting a router and there exists
no router in neutron. In that case there's nothing required to
synchronize. This patch fixes the synchronize decorator.

Fixes DHC-2627
