### PR TITLE
Add option to enable ceilometer notifications

### DIFF
--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -199,6 +199,17 @@ def register_and_load_opts():
                    help='name of the exchange where we receive RPC calls'),
     ])
 
+    ceilometer_group = cfg.OptGroup(name='ceilometer',
+                                    title='Ceilometer Reporting Options')
+    c_enable_reporting = cfg.BoolOpt('enabled', default=False)
+    c_topic = cfg.StrOpt('notification_topic',
+                         default='notifications.info',
+                         help='The name of the topic queue ceilometer '
+                              'consumes events from.')
+    cfg.CONF.register_group(ceilometer_group)
+    cfg.CONF.register_opt(c_enable_reporting, group=ceilometer_group)
+    cfg.CONF.register_opt(c_topic, group=ceilometer_group)
+
 
 def main(argv=sys.argv[1:]):
     # Change the process and thread name so the logs are cleaner.
@@ -260,12 +271,13 @@ def main(argv=sys.argv[1:]):
     )
     metadata_proc.start()
 
-    # Set up the notifications publisher
-    publisher = notifications.Publisher(
-        cfg.CONF.amqp_url,
-        exchange_name=cfg.CONF.outgoing_notifications_exchange,
-        topic='notifications.info',
-    )
+    if cfg.CONF.ceilometer.enabled:
+        # Set up the notifications publisher
+        publisher = notifications.Publisher(
+            cfg.CONF.amqp_url,
+            exchange_name=cfg.CONF.outgoing_notifications_exchange,
+            topic=cfg.CONF.ceilometer.topic,
+        )
 
     # Set up a factory to make Workers that know how many threads to
     # run.

--- a/etc/rug.ini
+++ b/etc/rug.ini
@@ -33,3 +33,7 @@ control_exchange = quantum
 
 [AGENT]
 root_helper=sudo
+
+[ceilometer]
+enabled = False
+topic = 'notifications.info'


### PR DESCRIPTION
This change introduces a configuration group for ceilometer
notifications. The default for akanda is to not publish notifications.
