### PR TITLE
Add toggle for notifications.Publisher

### DIFF
--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -271,13 +271,15 @@ def main(argv=sys.argv[1:]):
     )
     metadata_proc.start()
 
-    if cfg.CONF.ceilometer.enabled:
-        # Set up the notifications publisher
-        publisher = notifications.Publisher(
-            cfg.CONF.amqp_url,
-            exchange_name=cfg.CONF.outgoing_notifications_exchange,
-            topic=cfg.CONF.ceilometer.topic,
-        )
+    # Set up the notifications publisher
+    Publisher = (notifications.Publisher if cfg.CONF.ceilometer.enabled
+                 else notifications.NoopPublisher)
+    publisher = Publisher(
+        cfg.CONF.amqp_url,
+        exchange_name=cfg.CONF.outgoing_notifications_exchange,
+        topic=cfg.CONF.ceilometer.topic,
+        enabled=cfg.CONF.ceilometer.enabled
+    )
 
     # Set up a factory to make Workers that know how many threads to
     # run.

--- a/akanda/rug/main.py
+++ b/akanda/rug/main.py
@@ -202,7 +202,7 @@ def register_and_load_opts():
     ceilometer_group = cfg.OptGroup(name='ceilometer',
                                     title='Ceilometer Reporting Options')
     c_enable_reporting = cfg.BoolOpt('enabled', default=False)
-    c_topic = cfg.StrOpt('notification_topic',
+    c_topic = cfg.StrOpt('topic',
                          default='notifications.info',
                          help='The name of the topic queue ceilometer '
                               'consumes events from.')
@@ -278,7 +278,6 @@ def main(argv=sys.argv[1:]):
         cfg.CONF.amqp_url,
         exchange_name=cfg.CONF.outgoing_notifications_exchange,
         topic=cfg.CONF.ceilometer.topic,
-        enabled=cfg.CONF.ceilometer.enabled
     )
 
     # Set up a factory to make Workers that know how many threads to

--- a/akanda/rug/notifications.py
+++ b/akanda/rug/notifications.py
@@ -431,3 +431,26 @@ class Publisher(object):
                     sender.send(msg)
                 except Exception:
                     LOG.exception('could not publish notification')
+
+
+class NoopPublisher(Publisher):
+    """A Publisher that doesn't do anything.
+
+    The code that publishes notifications is spread across several
+    classes and cannot be easily disabled in configurations that do
+    not require sending metrics to ceilometer.
+
+    This class is used in place of the Publisher class to disable
+    sending metrics without explicitly checking in various places
+    across the code base.
+
+    """
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def publish(self, incoming):
+        pass


### PR DESCRIPTION
This commit adds a configuration group named, "ceilometer," and a boolean toggle to enable publishing notifications to the ceilometer queue. It defaults to "False" which makes the notifications.Publisher a no-op class since it is passed around to several areas of the code and none of which relies on return values of side-effects of calling methods on it.
