### PR TITLE
Refactor local port creation to avoid duplication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ install:
   - pip install flake8 --use-mirrors
   - pip install -q . --use-mirrors
 before_script:
-  - flake8 setup.py akanda
+  - flake8 setup.py akanda --ignore=E123,E133,E226,E241,E242,E731
 script: nosetests -d

--- a/tox.ini
+++ b/tox.ini
@@ -24,3 +24,6 @@ setenv = NOSE_WITH_COVERAGE=1
 
 [testenv:venv]
 commands = {posargs}
+
+[flake8]
+ignore = E123,E133,E226,E241,E242,E731


### PR DESCRIPTION
ensure_local_external_port and ensure_local_service_port
are basicly the same method with a few diferences.
Refactoring them to avoid duplicated code.

Change-Id: Ia38bf49222e8e75af8728f9a08d4705220795a60
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
