### PR TITLE
Fix a race condition that affects router VM boots.

### DIFF
--- a/akanda/rug/api/quantum.py
+++ b/akanda/rug/api/quantum.py
@@ -51,6 +51,10 @@ class RouterGone(Exception):
     pass
 
 
+class RouterGatewayMissing(Exception):
+    pass
+
+
 class MissingIPAllocation(Exception):
 
     def __init__(self, port_id, missing):
@@ -486,11 +490,11 @@ class Quantum(object):
             'external_gateway_info': network_args
         }
 
-        r = self.api_client.update_router(
+        self.api_client.update_router(
             router.id,
             body=dict(router=update_args)
         )
-        new_port = Router.from_dict(r['router']).external_port
+        new_port = self.get_router_external_port(router)
 
         # Make sure the port has enough IPs.
         subnets = self.get_network_subnets(self.conf.external_network_id)
@@ -512,6 +516,26 @@ class Quantum(object):
                  for mv in missing_versions]
             )
         return new_port
+
+    def get_router_external_port(self, router):
+        for i in xrange(self.conf.max_retries):
+            LOG.debug(
+                'Looking for router external port. Attempt %d of %d',
+                i,
+                cfg.CONF.max_retries,
+            )
+            ports = [
+                p for p in self.api_client.show_router(
+                    router.id
+                )['router']['ports']
+                if p['network_id'] == self.conf.external_network_id
+            ]
+            if len(ports):
+                port = Port.from_dict(ports[0])
+                LOG.debug('Found router external port: %s' % port.id)
+                return port
+            time.sleep(self.conf.retry_delay)
+        raise RouterGatewayMissing()
 
     def ensure_local_external_port(self):
         driver = importutils.import_object(self.conf.interface_driver,


### PR DESCRIPTION
In Icehouse, the `update_router` L3 API command changed so that the
process of setting (and potentially creating the gateway port) is no
longer synchronous and part of the database update.  Because of this, we
can no longer rely on calls of `update_router` to include port
information (because it may not have been created yet).  Instead, we need to poll a few
times with `show_router` until the gateway port has been created:

https://github.com/openstack/neutron/commit/f23f2ecee68ba4abd12139bbb91b77ba9410f581
