### PR TITLE
Fix issue with port creation on the mgt and public nets

### DIFF
--- a/akanda/rug/api/quantum.py
+++ b/akanda/rug/api/quantum.py
@@ -532,17 +532,17 @@ class Quantum(object):
                      network_type, port)
         else:
             LOG.info('creating a new local %s port', network_type)
-            port_dict = dict(
-                admin_state_up=True,
-                network_id=network_id,
-                device_owner=DEVICE_OWNER_RUG,
-                device_id=host_id,
-                fixed_ips=[{
+            port_dict = {
+                'admin_state_up': True,
+                'network_id': network_id,
+                'device_owner': DEVICE_OWNER_RUG,
+                'device_id': host_id,
+                'fixed_ips': [{
                     'ip_address': ip_address.split('/')[0],
                     'subnet_id': subnet_id
-                }]
-            )
-
+                }],
+                'binding:host_id': socket.gethostname()
+            }
             port = Port.from_dict(
                 self.api_client.create_port(dict(port=port_dict))['port'])
             LOG.info('new local %s port: %r', network_type, port)


### PR DESCRIPTION
With juno neutron the 'binding:host_id' param need to
be passed when a port is created otherwise the L2 agent
fails to bind it.

Change-Id: Ie5ed2c79b0f3c52994bf7b7412c9b5df389280da
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
