### PR TITLE
Perform the populate router fetch via the API rather than RPC.

### DIFF
--- a/akanda/rug/populate.py
+++ b/akanda/rug/populate.py
@@ -47,7 +47,7 @@ def _pre_populate_workers(scheduler):
 
     while True:
         try:
-            quantum_routers = quantum_client.get_routers()
+            quantum_routers = quantum_client.get_routers(detailed=False)
             break
         except (q_exceptions.Unauthorized, q_exceptions.Forbidden) as err:
             LOG.warning('PrePopulateWorkers thread failed: %s', err)


### PR DESCRIPTION
The RPC call is reserved for expensive, detailed fetches and for larger sets of
routers, is easy to time out on.  We're only using the list of routers to
generate an initial set of POLL events, so we can get by with the (much faster)
API call.
