### PR TITLE
Silence urllib3 logging messages running the rug-ctl browse command

### DIFF
--- a/akanda/rug/cli/browse.py
+++ b/akanda/rug/cli/browse.py
@@ -34,6 +34,8 @@ from akanda.rug.api import nova as nova_api
 from akanda.rug.api import quantum as quantum_api
 from akanda.rug.cli import message
 
+logging.getLogger("urllib3").setLevel(logging.ERROR)
+
 
 class FakeConfig(object):
 


### PR DESCRIPTION
The `rug-ctl browse` command spawns a bunch of threads that
use the novaclient to get the akanda routers status.
The novaclient indirectly uses the urllib3 library which
produces a log message every time a new connection is made.
Those messages break the output of the 'rug-ctl browse'
command.

Change-Id: If0f3715058705fefb2386dd7f78629844608f2c7
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
